### PR TITLE
8258015: [JVMCI] JVMCI_lock shouldn't be held while initializing box classes

### DIFF
--- a/src/hotspot/share/jvmci/jvmci.cpp
+++ b/src/hotspot/share/jvmci/jvmci.cpp
@@ -37,7 +37,7 @@
 JVMCIRuntime* JVMCI::_compiler_runtime = NULL;
 JVMCIRuntime* JVMCI::_java_runtime = NULL;
 volatile bool JVMCI::_is_initialized = false;
-volatile bool JVMCI::_box_caches_initialized = false;
+bool JVMCI::_box_caches_initialized = false;
 void* JVMCI::_shared_library_handle = NULL;
 char* JVMCI::_shared_library_path = NULL;
 volatile bool JVMCI::_in_shutdown = false;
@@ -130,12 +130,9 @@ void JVMCI::ensure_box_caches_initialized(TRAPS) {
   if (_box_caches_initialized) {
     return;
   }
-  MutexLocker locker(JVMCI_lock);
-  // Check again after locking
-  if (_box_caches_initialized) {
-    return;
-  }
 
+  // While multiple threads may reach here, that's fine
+  // since class initialization is synchronized.
   Symbol* box_classes[] = {
     java_lang_Boolean::symbol(),
     java_lang_Byte_ByteCache::symbol(),

--- a/src/hotspot/share/jvmci/jvmci.hpp
+++ b/src/hotspot/share/jvmci/jvmci.hpp
@@ -53,8 +53,8 @@ class JVMCI : public AllStatic {
   // execution has completed successfully.
   static volatile bool _is_initialized;
 
-  // used to synchronize lazy initialization of boxing cache classes.
-  static volatile bool _box_caches_initialized;
+  // True once boxing cache classes are guaranteed to be initialized.
+  static bool _box_caches_initialized;
 
   // Handle created when loading the JVMCI shared library with os::dll_load.
   // Must hold JVMCI_lock when initializing.

--- a/src/hotspot/share/jvmci/jvmciCodeInstaller.hpp
+++ b/src/hotspot/share/jvmci/jvmciCodeInstaller.hpp
@@ -200,6 +200,7 @@ private:
   Dependencies*             _dependencies;
   ExceptionHandlerTable     _exception_handler_table;
   ImplicitExceptionTable    _implicit_exception_table;
+  bool                      _has_auto_box;
 
   bool _immutable_pic_compilation;  // Installer is called for Immutable PIC compilation.
 
@@ -230,7 +231,11 @@ private:
 
 public:
 
-  CodeInstaller(JVMCIEnv* jvmci_env, bool immutable_pic_compilation) : _arena(mtJVMCI), _jvmci_env(jvmci_env), _immutable_pic_compilation(immutable_pic_compilation) {}
+  CodeInstaller(JVMCIEnv* jvmci_env, bool immutable_pic_compilation) :
+    _arena(mtJVMCI),
+    _jvmci_env(jvmci_env),
+    _has_auto_box(false),
+    _immutable_pic_compilation(immutable_pic_compilation) {}
 
 #if INCLUDE_AOT
   JVMCI::CodeInstallResult gather_metadata(JVMCIObject target, JVMCIObject compiled_code, CodeMetadata& metadata, JVMCI_TRAPS);


### PR DESCRIPTION
Backport of https://bugs.openjdk.java.net/browse/JDK-8258015.

Applies cleanly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258015](https://bugs.openjdk.java.net/browse/JDK-8258015): [JVMCI] JVMCI_lock shouldn't be held while initializing box classes

### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/1/head:pull/1`
`$ git checkout pull/1`
