### PR TITLE
8258060: Update @jls tags for renamed/renumbered sections

### DIFF
--- a/src/java.compiler/share/classes/javax/annotation/processing/RoundEnvironment.java
+++ b/src/java.compiler/share/classes/javax/annotation/processing/RoundEnvironment.java
@@ -109,7 +109,7 @@ public interface RoundEnvironment {
      * annotation types, or an empty set if there are none
      * @throws IllegalArgumentException if the any elements of the
      * argument set do not represent an annotation type
-     * @jls 9.6.3 Repeatable Annotation Types
+     * @jls 9.6.3 Repeatable Annotation Interfaces
      * @since 9
      */
     default Set<? extends Element> getElementsAnnotatedWithAny(TypeElement... annotations){
@@ -191,7 +191,7 @@ public interface RoundEnvironment {
      * annotation types, or an empty set if there are none
      * @throws IllegalArgumentException if the any elements of the
      * argument set do not represent an annotation type
-     * @jls 9.6.3 Repeatable Annotation Types
+     * @jls 9.6.3 Repeatable Annotation Interfaces
      *
      * @see javax.lang.model.AnnotatedConstruct#getAnnotation(Class)
      * @see javax.lang.model.AnnotatedConstruct#getAnnotationsByType(Class)

--- a/src/java.compiler/share/classes/javax/lang/model/AnnotatedConstruct.java
+++ b/src/java.compiler/share/classes/javax/lang/model/AnnotatedConstruct.java
@@ -129,10 +129,10 @@ import javax.lang.model.type.*;
  * </ul>
  *
  * @since 1.8
- * @jls 9.6 Annotation Types
+ * @jls 9.6 Annotation Interfaces
  * @jls 9.6.4.3 {@code @Inherited}
  * @jls 9.7.4 Where Annotations May Appear
- * @jls 9.7.5 Multiple Annotations of the Same Type
+ * @jls 9.7.5 Multiple Annotations of the Same Interface
  */
 public interface AnnotatedConstruct {
     /**
@@ -184,7 +184,7 @@ public interface AnnotatedConstruct {
      * @see IncompleteAnnotationException
      * @see MirroredTypeException
      * @see MirroredTypesException
-     * @jls 9.6.1 Annotation Type Elements
+     * @jls 9.6.1 Annotation Elements
      */
     <A extends Annotation> A getAnnotation(Class<A> annotationType);
 
@@ -244,8 +244,8 @@ public interface AnnotatedConstruct {
      * @see IncompleteAnnotationException
      * @see MirroredTypeException
      * @see MirroredTypesException
-     * @jls 9.6 Annotation Types
-     * @jls 9.6.1 Annotation Type Elements
+     * @jls 9.6 Annotation Interfaces
+     * @jls 9.6.1 Annotation Elements
      */
     <A extends Annotation> A[] getAnnotationsByType(Class<A> annotationType);
 }

--- a/src/java.compiler/share/classes/javax/lang/model/AnnotatedConstruct.java
+++ b/src/java.compiler/share/classes/javax/lang/model/AnnotatedConstruct.java
@@ -184,7 +184,7 @@ public interface AnnotatedConstruct {
      * @see IncompleteAnnotationException
      * @see MirroredTypeException
      * @see MirroredTypesException
-     * @jls 9.6.1 Annotation Elements
+     * @jls 9.6.1 Annotation Interface Elements
      */
     <A extends Annotation> A getAnnotation(Class<A> annotationType);
 
@@ -245,7 +245,7 @@ public interface AnnotatedConstruct {
      * @see MirroredTypeException
      * @see MirroredTypesException
      * @jls 9.6 Annotation Interfaces
-     * @jls 9.6.1 Annotation Elements
+     * @jls 9.6.1 Annotation Interface Elements
      */
     <A extends Annotation> A[] getAnnotationsByType(Class<A> annotationType);
 }

--- a/src/java.compiler/share/classes/javax/lang/model/element/Element.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/Element.java
@@ -229,7 +229,7 @@ public interface Element extends javax.lang.model.AnnotatedConstruct {
      * @see ModuleElement#getEnclosedElements
      * @see Elements#getAllMembers
      * @jls 8.8.9 Default Constructor
-     * @jls 8.9 Enum Types
+     * @jls 8.9 Enum Classes
      * @revised 9
      */
     List<? extends Element> getEnclosedElements();

--- a/src/java.compiler/share/classes/javax/lang/model/element/NestingKind.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/NestingKind.java
@@ -91,7 +91,7 @@ public enum NestingKind {
     /**
      * A class or interface that is a named member of another class or
      * interface.
-     * @jls 8.5 Member Type Declarations
+     * @jls 8.5 Member Class and Interface Declarations
      */
     MEMBER,
 

--- a/src/java.compiler/share/classes/javax/lang/model/element/package-info.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/package-info.java
@@ -116,7 +116,7 @@
  * @jls 8.1 Class Declarations
  * @jls 8.3 Field Declarations
  * @jls 8.4 Method Declarations
- * @jls 8.5 Member Type Declarations
+ * @jls 8.5 Member Class and Interface Declarations
  * @jls 8.8 Constructor Declarations
  * @jls 9.1 Interface Declarations
  * @since 1.6

--- a/src/java.compiler/share/classes/javax/lang/model/util/Elements.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/Elements.java
@@ -354,7 +354,7 @@ public interface Elements {
      * @param c the construct the annotation mirror modifies
      * @param a the annotation mirror being examined
      * @jls 9.6.3 Repeatable Annotation Types
-     * @jls 9.7.5 Multiple Annotations of the Same Type
+     * @jls 9.7.5 Multiple Annotations of the Same Interface
      * @since 9
      */
     default Origin getOrigin(AnnotatedConstruct c,
@@ -428,7 +428,7 @@ public interface Elements {
          * @jls 8.8.9 Default Constructor
          * @jls 8.9.3 Enum Members
          * @jls 9.6.3 Repeatable Annotation Types
-         * @jls 9.7.5 Multiple Annotations of the Same Type
+         * @jls 9.7.5 Multiple Annotations of the Same Interface
          */
         MANDATED,
 


### PR DESCRIPTION
Given upcoming changes in the JLS terminology around the term "type", various sections were renamed:

    https://download.java.net/java/early_access/jdk16/docs/specs/class-terminology-jls.html

The @jls tags in the java.compiler module which refer to the renamed sections should be updated.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258060](https://bugs.openjdk.java.net/browse/JDK-8258060): Update @jls tags for renamed/renumbered sections


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**) ⚠️ Review applies to 9985bdbde9be32739cd774dec75d793aad8832ed
 * abuckley - Committer ⚠️ Added manually

### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/4/head:pull/4`
`$ git checkout pull/4`
