### PR TITLE
8257919: [JVMCI] profiling info didn't change after reprofile

### DIFF
--- a/src/hotspot/share/ci/ciMethodData.cpp
+++ b/src/hotspot/share/ci/ciMethodData.cpp
@@ -47,6 +47,7 @@ ciMethodData::ciMethodData(MethodData* md)
   _saw_free_extra_data(false),
   // Initialize the escape information (to "don't know.");
   _eflags(0), _arg_local(0), _arg_stack(0), _arg_returned(0),
+  _creation_mileage(0),
   _current_mileage(0),
   _invocation_counter(0),
   _backedge_counter(0),
@@ -242,6 +243,7 @@ void ciMethodData::load_data() {
   load_remaining_extra_data();
 
   // Note:  Extra data are all BitData, and do not need translation.
+  _creation_mileage = mdo->creation_mileage();
   _current_mileage = MethodData::mileage_of(mdo->method());
   _invocation_counter = mdo->invocation_count();
   _backedge_counter = mdo->backedge_count();

--- a/src/hotspot/share/ci/ciMethodData.hpp
+++ b/src/hotspot/share/ci/ciMethodData.hpp
@@ -395,6 +395,8 @@ private:
   intx _arg_stack;    // bit set of stack-allocatable arguments
   intx _arg_returned; // bit set of returned arguments
 
+  int _creation_mileage; // method mileage at MDO creation
+
   // Maturity of the oop when the snapshot is taken.
   int _current_mileage;
 
@@ -475,7 +477,7 @@ public:
   bool is_empty()  { return _state == empty_state; }
   bool is_mature() { return _state == mature_state; }
 
-  int creation_mileage() { return _orig.creation_mileage(); }
+  int creation_mileage() { return _creation_mileage; }
   int current_mileage()  { return _current_mileage; }
 
   int invocation_count() { return _invocation_counter; }

--- a/src/hotspot/share/oops/methodData.cpp
+++ b/src/hotspot/share/oops/methodData.cpp
@@ -1281,6 +1281,7 @@ void MethodData::initialize() {
 }
 
 void MethodData::init() {
+  _compiler_counters = CompilerCounters(_method); // reset compiler counters
   _invocation_counter.init();
   _backedge_counter.init();
   _invocation_counter_start = 0;

--- a/src/hotspot/share/oops/methodData.cpp
+++ b/src/hotspot/share/oops/methodData.cpp
@@ -1206,7 +1206,7 @@ void MethodData::post_initialize(BytecodeStream* stream) {
 MethodData::MethodData(const methodHandle& method)
   : _method(method()),
     _extra_data_lock(Mutex::leaf, "MDO extra data lock"),
-    _compiler_counters(method()),
+    _compiler_counters(),
     _parameters_type_data_di(parameters_uninitialized) {
   initialize();
 }
@@ -1217,6 +1217,7 @@ void MethodData::initialize() {
   ResourceMark rm(thread);
 
   init();
+  set_creation_mileage(mileage_of(method()));
 
   // Go through the bytecodes and allocate and initialize the
   // corresponding data cells.
@@ -1281,7 +1282,7 @@ void MethodData::initialize() {
 }
 
 void MethodData::init() {
-  _compiler_counters = CompilerCounters(_method); // reset compiler counters
+  _compiler_counters = CompilerCounters(); // reset compiler counters
   _invocation_counter.init();
   _backedge_counter.init();
   _invocation_counter_start = 0;

--- a/src/hotspot/share/oops/methodData.hpp
+++ b/src/hotspot/share/oops/methodData.hpp
@@ -1974,7 +1974,6 @@ public:
     friend class VMStructs;
     friend class JVMCIVMStructs;
 
-    int  _creation_mileage;           // method mileage at MDO creation
     uint _nof_decompiles;             // count of all nmethod removals
     uint _nof_overflow_recompiles;    // recompile count, excluding recomp. bits
     uint _nof_overflow_traps;         // trap count, excluding _trap_hist
@@ -1983,16 +1982,12 @@ public:
       u1 _array[JVMCI_ONLY(2 *) MethodData::_trap_hist_limit];
     } _trap_hist;
 
-    CompilerCounters(int current_mileage) : _creation_mileage(current_mileage), _nof_decompiles(0), _nof_overflow_recompiles(0), _nof_overflow_traps(0) {
+  public:
+    CompilerCounters() : _nof_decompiles(0), _nof_overflow_recompiles(0), _nof_overflow_traps(0) {
       static_assert(sizeof(_trap_hist) % HeapWordSize == 0, "align");
       uint size_in_words = sizeof(_trap_hist) / HeapWordSize;
       Copy::zero_to_words((HeapWord*) &_trap_hist, size_in_words);
     }
-  public:
-    CompilerCounters(Method* m) : CompilerCounters(MethodData::mileage_of(m)) {}
-    CompilerCounters() : CompilerCounters(0) {} // for ciMethodData
-
-    int      creation_mileage() const { return _creation_mileage; }
 
     // Return (uint)-1 for overflow.
     uint trap_count(int reason) const {
@@ -2043,6 +2038,8 @@ private:
   intx              _arg_local;       // bit set of non-escaping arguments
   intx              _arg_stack;       // bit set of stack-allocatable arguments
   intx              _arg_returned;    // bit set of returned arguments
+
+  int               _creation_mileage; // method mileage at MDO creation
 
   // How many invocations has this MDO seen?
   // These counters are used to determine the exact age of MDO.
@@ -2188,7 +2185,8 @@ public:
   int size_in_bytes() const { return _size; }
   int size() const    { return align_metadata_size(align_up(_size, BytesPerWord)/BytesPerWord); }
 
-  int      creation_mileage() const { return _compiler_counters.creation_mileage(); }
+  int      creation_mileage() const { return _creation_mileage; }
+  void set_creation_mileage(int x)  { _creation_mileage = x; }
 
   int invocation_count() {
     if (invocation_counter()->carry()) {

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -44,8 +44,6 @@ compiler/ciReplay/TestSAServer.java 8029528 generic-all
 compiler/codecache/jmx/PoolsIndependenceTest.java 8167015 generic-all
 compiler/compilercontrol/jcmd/ClearDirectivesFileStackTest.java 8225370 generic-all
 compiler/jvmci/compilerToVM/GetFlagValueTest.java 8204459 generic-all
-compiler/jvmci/compilerToVM/IsMatureVsReprofileTest.java 8257919 generic-all
-compiler/jvmci/compilerToVM/ReprofileTest.java 8257919 generic-all
 compiler/tiered/LevelTransitionTest.java 8067651 generic-all
 
 compiler/cpuflags/TestAESIntrinsicsOnSupportedConfig.java 8190680 generic-all


### PR DESCRIPTION
JDK-8252049 moved compiler counter initialization into MethodData constructor, but JVMCI and WhiteBox API rely on `MethodData::initialize()`/`MethodData::init()` to reset MDO state. 

Proposed fix restores the logic which resets the counters in `init()` (which is called from `initialize()`).

Testing:
- [x] hs-precheckin-comp, hs-tier1, hs-tier2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257919](https://bugs.openjdk.java.net/browse/JDK-8257919): [JVMCI] profiling info didn't change after reprofile


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/6/head:pull/6`
`$ git checkout pull/6`
