### PR TITLE
8258092: Link to early access platform documentation in TestHtmlTableTags.java

### DIFF
--- a/test/langtools/jdk/javadoc/doclet/testHtmlTableTags/TestHtmlTableTags.java
+++ b/test/langtools/jdk/javadoc/doclet/testHtmlTableTags/TestHtmlTableTags.java
@@ -51,6 +51,7 @@ public class TestHtmlTableTags extends JavadocTester {
         javadoc("-d", "out",
                 "-sourcepath", testSrc,
                 "-use",
+                "--no-platform-links",
                 "pkg1", "pkg2");
         checkExit(Exit.OK);
 
@@ -66,6 +67,7 @@ public class TestHtmlTableTags extends JavadocTester {
                 "-nocomment",
                 "-sourcepath", testSrc,
                 "-use",
+                "--no-platform-links",
                 "pkg1", "pkg2");
         checkExit(Exit.OK);
 
@@ -683,12 +685,8 @@ public class TestHtmlTableTags extends JavadocTester {
         // Constant values
         checkOutput("constant-values.html", true,
                 """
-                    <div class="col-first even-row-color"><code id="pkg1.C1.CONSTANT1">public&nbsp;s\
-                    tatic&nbsp;final&nbsp;<a href="https://download.java.net/java/early_access/jdk16\
-                    /docs/api/java.base/java/lang/String.html" title="class or interface in java.lan\
-                    g" class="external-link">String</a></code></div>
-                    <div class="col-second even-row-color"><code><a href="pkg1/C1.html#CONSTANT1">CO\
-                    NSTANT1</a></code></div>
+                    <div class="col-first even-row-color"><code id="pkg1.C1.CONSTANT1">public&nbsp;static&nbsp;final&nbsp;java.lang.String</code></div>
+                    <div class="col-second even-row-color"><code><a href="pkg1/C1.html#CONSTANT1">CONSTANT1</a></code></div>
                     <div class="col-last even-row-color"><code>"C1"</code></div>
                     </div>""");
 
@@ -814,12 +812,8 @@ public class TestHtmlTableTags extends JavadocTester {
         // Constant values
         checkOutput("constant-values.html", true,
                 """
-                    <div class="col-first even-row-color"><code id="pkg1.C1.CONSTANT1">public&nbsp;s\
-                    tatic&nbsp;final&nbsp;<a href="https://download.java.net/java/early_access/jdk16\
-                    /docs/api/java.base/java/lang/String.html" title="class or interface in java.lan\
-                    g" class="external-link">String</a></code></div>
-                    <div class="col-second even-row-color"><code><a href="pkg1/C1.html#CONSTANT1">CO\
-                    NSTANT1</a></code></div>
+                    <div class="col-first even-row-color"><code id="pkg1.C1.CONSTANT1">public&nbsp;static&nbsp;final&nbsp;java.lang.String</code></div>
+                    <div class="col-second even-row-color"><code><a href="pkg1/C1.html#CONSTANT1">CONSTANT1</a></code></div>
                     <div class="col-last even-row-color"><code>"C1"</code></div>
                     </div>""");
 


### PR DESCRIPTION
I recently added tests that expect javadoc output to contain links to early access jdk 16 platform documentation. 

This fix adds the `--no-platform-links` option to the tests in question and updates the expected output accordingly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258092](https://bugs.openjdk.java.net/browse/JDK-8258092): Link to early access platform documentation in TestHtmlTableTags.java


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/10/head:pull/10`
`$ git checkout pull/10`
