### PR TITLE
8258101: compiler/blackhole tests should not run with -Xcomp

### DIFF
--- a/test/hotspot/jtreg/compiler/blackhole/BlackholeInstanceReturnTest.java
+++ b/test/hotspot/jtreg/compiler/blackhole/BlackholeInstanceReturnTest.java
@@ -23,6 +23,7 @@
 
 /**
  * @test id=c1
+ * @requires vm.compMode != "Xcomp"
  * @build compiler.blackhole.BlackholeTarget
  *
  * @run main/othervm
@@ -35,6 +36,7 @@
 
 /**
  * @test id=c2
+ * @requires vm.compMode != "Xcomp"
  * @build compiler.blackhole.BlackholeTarget
  *
  * @run main/othervm
@@ -47,6 +49,7 @@
 
 /**
  * @test id=c1-no-coops
+ * @requires vm.compMode != "Xcomp"
  * @requires vm.bits == "64"
  * @build compiler.blackhole.BlackholeTarget
  *
@@ -60,6 +63,7 @@
 
 /**
  * @test id=c2-no-coops
+ * @requires vm.compMode != "Xcomp"
  * @requires vm.bits == "64"
  * @build compiler.blackhole.BlackholeTarget
  *

--- a/test/hotspot/jtreg/compiler/blackhole/BlackholeInstanceTest.java
+++ b/test/hotspot/jtreg/compiler/blackhole/BlackholeInstanceTest.java
@@ -23,6 +23,7 @@
 
 /**
  * @test id=c1
+ * @requires vm.compMode != "Xcomp"
  * @build compiler.blackhole.BlackholeTarget
  *
  * @run main/othervm
@@ -35,6 +36,7 @@
 
 /**
  * @test id=c2
+ * @requires vm.compMode != "Xcomp"
  * @build compiler.blackhole.BlackholeTarget
  *
  * @run main/othervm
@@ -47,6 +49,7 @@
 
 /**
  * @test id=c1-no-coops
+ * @requires vm.compMode != "Xcomp"
  * @requires vm.bits == "64"
  * @build compiler.blackhole.BlackholeTarget
  *
@@ -60,6 +63,7 @@
 
 /**
  * @test id=c2-no-coops
+ * @requires vm.compMode != "Xcomp"
  * @requires vm.bits == "64"
  * @build compiler.blackhole.BlackholeTarget
  *

--- a/test/hotspot/jtreg/compiler/blackhole/BlackholeNullCheckTest.java
+++ b/test/hotspot/jtreg/compiler/blackhole/BlackholeNullCheckTest.java
@@ -23,6 +23,7 @@
 
 /**
  * @test id=c1
+ * @requires vm.compMode != "Xcomp"
  * @build compiler.blackhole.BlackholeTarget
  *
  * @run main/othervm
@@ -35,6 +36,7 @@
 
 /**
  * @test id=c2
+ * @requires vm.compMode != "Xcomp"
  * @build compiler.blackhole.BlackholeTarget
  *
  * @run main/othervm
@@ -47,6 +49,7 @@
 
 /**
  * @test id=c1-no-coops
+ * @requires vm.compMode != "Xcomp"
  * @requires vm.bits == "64"
  * @build compiler.blackhole.BlackholeTarget
  *
@@ -60,6 +63,7 @@
 
 /**
  * @test id=c2-no-coops
+ * @requires vm.compMode != "Xcomp"
  * @requires vm.bits == "64"
  * @build compiler.blackhole.BlackholeTarget
  *

--- a/test/hotspot/jtreg/compiler/blackhole/BlackholeStaticReturnTest.java
+++ b/test/hotspot/jtreg/compiler/blackhole/BlackholeStaticReturnTest.java
@@ -23,6 +23,7 @@
 
 /**
  * @test id=c1
+ * @requires vm.compMode != "Xcomp"
  * @build compiler.blackhole.BlackholeTarget
  *
  * @run main/othervm
@@ -35,6 +36,7 @@
 
 /**
  * @test id=c2
+ * @requires vm.compMode != "Xcomp"
  * @build compiler.blackhole.BlackholeTarget
  *
  * @run main/othervm
@@ -47,6 +49,7 @@
 
 /**
  * @test id=c1-no-coops
+ * @requires vm.compMode != "Xcomp"
  * @requires vm.bits == "64"
  * @build compiler.blackhole.BlackholeTarget
  *
@@ -60,6 +63,7 @@
 
 /**
  * @test id=c2-no-coops
+ * @requires vm.compMode != "Xcomp"
  * @requires vm.bits == "64"
  * @build compiler.blackhole.BlackholeTarget
  *

--- a/test/hotspot/jtreg/compiler/blackhole/BlackholeStaticTest.java
+++ b/test/hotspot/jtreg/compiler/blackhole/BlackholeStaticTest.java
@@ -23,6 +23,7 @@
 
 /**
  * @test id=c1
+ * @requires vm.compMode != "Xcomp"
  * @build compiler.blackhole.BlackholeTarget
  *
  * @run main/othervm
@@ -35,6 +36,7 @@
 
 /**
  * @test id=c2
+ * @requires vm.compMode != "Xcomp"
  * @build compiler.blackhole.BlackholeTarget
  *
  * @run main/othervm
@@ -47,6 +49,7 @@
 
 /**
  * @test id=c1-no-coops
+ * @requires vm.compMode != "Xcomp"
  * @requires vm.bits == "64"
  * @build compiler.blackhole.BlackholeTarget
  *
@@ -60,6 +63,7 @@
 
 /**
  * @test id=c2-no-coops
+ * @requires vm.compMode != "Xcomp"
  * @requires vm.bits == "64"
  * @build compiler.blackhole.BlackholeTarget
  *


### PR DESCRIPTION
`compiler/blackhole` tests are not supposed to run with `-Xcomp`, and they fail when `-Xcomp` is supplied. The underlying reason is elusive. Draft PR just disables the tests for Xcomp.

Additional testing:
 - [x] Linux x86_64 `compiler/blackhole` tests (default)
 - [x] Linux x86_64 `compiler/blackhole` tests (-Xcomp) -- used to fail, now pass

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Error
&nbsp;⚠️ 8258101 is used in problem lists: [test/hotspot/jtreg/ProblemList-Xcomp.txt]

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8258101](https://bugs.openjdk.java.net/browse/JDK-8258101)

### Issue
 * [JDK-8258101](https://bugs.openjdk.java.net/browse/JDK-8258101): compiler/blackhole tests fail with -Xcomp ⚠️ Title mismatch between PR and JBS.


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/12/head:pull/12`
`$ git checkout pull/12`
