### PR TITLE
8258111: Problemlist compiler/blackhole tests for -Xcomp until JDK-8258101 is fixed

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -28,3 +28,26 @@
 #############################################################################
 
 vmTestbase/nsk/jvmti/SetFieldAccessWatch/setfldw001/TestDescription.java 8205957 generic-all
+
+compiler/blackhole/BlackholeDiagnosticUnlockTest.java           8258101 generic-all
+compiler/blackhole/BlackholeInstanceReturnTest.java#c1          8258101 generic-all
+compiler/blackhole/BlackholeInstanceReturnTest.java#c1-no-coops 8258101 generic-all
+compiler/blackhole/BlackholeInstanceReturnTest.java#c2          8258101 generic-all
+compiler/blackhole/BlackholeInstanceReturnTest.java#c2-no-coops 8258101 generic-all
+compiler/blackhole/BlackholeInstanceTest.java#c1                8258101 generic-all
+compiler/blackhole/BlackholeInstanceTest.java#c1-no-coops       8258101 generic-all
+compiler/blackhole/BlackholeInstanceTest.java#c2                8258101 generic-all
+compiler/blackhole/BlackholeInstanceTest.java#c2-no-coops       8258101 generic-all
+compiler/blackhole/BlackholeNonVoidWarningTest.java             8258101 generic-all
+compiler/blackhole/BlackholeNullCheckTest.java#c1               8258101 generic-all
+compiler/blackhole/BlackholeNullCheckTest.java#c1-no-coops      8258101 generic-all
+compiler/blackhole/BlackholeNullCheckTest.java#c2               8258101 generic-all
+compiler/blackhole/BlackholeNullCheckTest.java#c2-no-coops      8258101 generic-all
+compiler/blackhole/BlackholeStaticReturnTest.java#c1            8258101 generic-all
+compiler/blackhole/BlackholeStaticReturnTest.java#c1-no-coops   8258101 generic-all
+compiler/blackhole/BlackholeStaticReturnTest.java#c2            8258101 generic-all
+compiler/blackhole/BlackholeStaticReturnTest.java#c2-no-coops   8258101 generic-all
+compiler/blackhole/BlackholeStaticTest.java#c1                  8258101 generic-all
+compiler/blackhole/BlackholeStaticTest.java#c1-no-coops         8258101 generic-all
+compiler/blackhole/BlackholeStaticTest.java#c2                  8258101 generic-all
+compiler/blackhole/BlackholeStaticTest.java#c2-no-coops         8258101 generic-all


### PR DESCRIPTION
See JDK-8258101. Need more time to investigate this, and meanwhile Xcomp runs should be clean.

Additional testing:
 - [x] make run-test TEST=compiler/blackhole JTREG="EXTRA_PROBLEM_LISTS=./ProblemList-Xcomp.txt" -- ignores all tests

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258111](https://bugs.openjdk.java.net/browse/JDK-8258111): Problemlist compiler/blackhole tests for -Xcomp until JDK-8258101 is fixed


### Reviewers
 * [Igor Ignatyev](https://openjdk.java.net/census#iignatyev) (@iignatev - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/13/head:pull/13`
`$ git checkout pull/13`
