### PR TITLE
8258140: Update @jls tags in java.base for renamed/renumbered sections

### DIFF
--- a/src/java.base/share/classes/java/lang/Enum.java
+++ b/src/java.base/share/classes/java/lang/Enum.java
@@ -66,7 +66,7 @@ import static java.util.Objects.requireNonNull;
  * @see     Class#getEnumConstants()
  * @see     java.util.EnumSet
  * @see     java.util.EnumMap
- * @jls 8.9 Enum Types
+ * @jls 8.9 Enum Classes
  * @jls 8.9.3 Enum Members
  * @since   1.5
  */

--- a/src/java.base/share/classes/java/lang/annotation/Repeatable.java
+++ b/src/java.base/share/classes/java/lang/annotation/Repeatable.java
@@ -33,8 +33,8 @@ package java.lang.annotation;
  * type</em> for the repeatable annotation type.
  *
  * @since 1.8
- * @jls 9.6.3 Repeatable Annotation Types
- * @jls 9.7.5 Multiple Annotations of the Same Type
+ * @jls 9.6.3 Repeatable Annotation Interfaces
+ * @jls 9.7.5 Multiple Annotations of the Same Interface
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)

--- a/src/java.base/share/classes/java/lang/annotation/Target.java
+++ b/src/java.base/share/classes/java/lang/annotation/Target.java
@@ -72,7 +72,7 @@ package java.lang.annotation;
  * @since 1.5
  * @jls 9.6.4.1 @Target
  * @jls 9.7.4 Where Annotations May Appear
- * @jls 9.7.5 Multiple Annotations of the Same Type
+ * @jls 9.7.5 Multiple Annotations of the Same Interface
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)

--- a/src/java.base/share/classes/java/lang/reflect/Method.java
+++ b/src/java.base/share/classes/java/lang/reflect/Method.java
@@ -405,7 +405,7 @@ public final class Method extends Executable {
      *
      * @jls 8.4.3 Method Modifiers
      * @jls 9.4 Method Declarations
-     * @jls 9.6.1 Annotation Type Elements
+     * @jls 9.6.1 Annotation Interface Elements
      */
     public String toString() {
         return sharedToString(Modifier.methodModifiers(),
@@ -475,7 +475,7 @@ public final class Method extends Executable {
      *
      * @jls 8.4.3 Method Modifiers
      * @jls 9.4 Method Declarations
-     * @jls 9.6.1 Annotation Type Elements
+     * @jls 9.6.1 Annotation Interface Elements
      */
     @Override
     public String toGenericString() {


### PR DESCRIPTION
Given upcoming changes in the JLS terminology around the term "type", various sections were renamed:

    https://download.java.net/java/early_access/jdk16/docs/specs/class-terminology-jls.html

The @jls tags in the java.base module which refer to the renamed sections should be updated.
 Analogous changes in the java.compiler module made under JDK-8258060.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258140](https://bugs.openjdk.java.net/browse/JDK-8258140): Update @jls tags in java.base for renamed/renumbered sections


### Reviewers
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/15/head:pull/15`
`$ git checkout pull/15`
