### PR TITLE
8254350: CompletableFuture.get may swallow InterruptedException

### DIFF
--- a/test/jdk/java/util/concurrent/CompletableFuture/LostInterrupt.java
+++ b/test/jdk/java/util/concurrent/CompletableFuture/LostInterrupt.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ThreadLocalRandom;
+import static java.util.concurrent.TimeUnit.DAYS;
+
+/*
+ * @test
+ * @bug 8254350
+ * @run main LostInterrupt
+ * @summary CompletableFuture.get may swallow interrupt status
+ * @key randomness
+ */
+
+// TODO: Rewrite as a CompletableFuture tck test ?
+
+/**
+ * Submits a task that completes immediately, then invokes CompletableFuture.get
+ * with the interrupt status set. CompletableFuture.get should either complete
+ * immediately with the interrupt status set, or else throw InterruptedException
+ * with the interrupt status cleared.
+ */
+public class LostInterrupt {
+    static final int ITERATIONS = 10_000;
+
+    public static void main(String[] args) throws Exception {
+        ThreadLocalRandom rnd = ThreadLocalRandom.current();
+        ForkJoinPool executor = new ForkJoinPool(1);
+        try {
+            for (int i = 0; i < ITERATIONS; i++) {
+                CompletableFuture<String> future = new CompletableFuture<>();
+                boolean timed = rnd.nextBoolean();
+                executor.execute(() -> future.complete("foo"));
+
+                Thread.currentThread().interrupt();
+                try {
+                    String result = timed ? future.get(1, DAYS) : future.get();
+
+                    if (!Thread.interrupted())
+                        throw new AssertionError("lost interrupt, run=" + i);
+                } catch (InterruptedException expected) {
+                    if (Thread.interrupted())
+                        throw new AssertionError(
+                            "interrupt status not cleared, run=" + i);
+                }
+            }
+        } finally {
+            executor.shutdown();
+        }
+    }
+}

--- a/test/jdk/java/util/concurrent/CompletableFuture/SwallowedInterruptedException.java
+++ b/test/jdk/java/util/concurrent/CompletableFuture/SwallowedInterruptedException.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicReference;
+
+/*
+ * @test
+ * @bug 8254350
+ * @run main SwallowedInterruptedException
+ * @key randomness
+ */
+
+public class SwallowedInterruptedException {
+    static final int ITERATIONS = 100;
+
+    public static void main(String[] args) throws Throwable {
+        for (int i = 1; i <= ITERATIONS; i++) {
+            System.out.format("Iteration %d%n", i);
+
+            CompletableFuture<Void> future = new CompletableFuture<>();
+            CountDownLatch running = new CountDownLatch(1);
+            AtomicReference<String> failed = new AtomicReference<>();
+
+            Thread thread = new Thread(() -> {
+                // signal main thread that child is running
+                running.countDown();
+
+                // invoke Future.get, it complete with the interrupt status set or
+                // else throw InterruptedException with the interrupt status not set.
+                try {
+                    future.get();
+
+                    // interrupt status should be set
+                    if (!Thread.currentThread().isInterrupted()) {
+                        failed.set("Future.get completed with interrupt status not set");
+                    }
+                } catch (InterruptedException ex) {
+                    // interrupt status should be cleared
+                    if (Thread.currentThread().isInterrupted()) {
+                        failed.set("InterruptedException with interrupt status set");
+                    }
+                } catch (Throwable ex) {
+                    failed.set("Unexpected exception " + ex);
+                }
+            });
+            thread.setDaemon(true);
+            thread.start();
+
+            // wait for thread to run
+            running.await();
+
+            // interrupt thread and set result after an optional (random) delay
+            thread.interrupt();
+            long sleepMillis = ThreadLocalRandom.current().nextLong(10);
+            if (sleepMillis > 0)
+                Thread.sleep(sleepMillis);
+            future.complete(null);
+
+            // wait for thread to terminate and check for failure
+            thread.join();
+            String failedReason = failed.get();
+            if (failedReason != null) {
+                throw new RuntimeException("Test failed: " + failedReason);
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254350](https://bugs.openjdk.java.net/browse/JDK-8254350): CompletableFuture.get may swallow InterruptedException


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Doug Lea](https://openjdk.java.net/census#dl) (@DougLea - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/17/head:pull/17`
`$ git checkout pull/17`
