### PR TITLE
8258242: Type profile pollution occurs when memory segments of different kinds are used

### DIFF
--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -353,6 +353,7 @@
   /* Panama Support */                                                                                          \
   template(jdk_internal_invoke_NativeEntryPoint,                 "jdk/internal/invoke/NativeEntryPoint")           \
   template(jdk_internal_invoke_NativeEntryPoint_signature,       "Ljdk/internal/invoke/NativeEntryPoint;")         \
+  template(jdk_incubator_foreign_MemoryAccess,       "jdk/incubator/foreign/MemoryAccess")        \
                                                                                                   \
   /* Support for JVMCI */                                                                         \
   JVMCI_VM_SYMBOLS_DO(template, do_alias)                                                         \

--- a/src/hotspot/share/oops/methodData.cpp
+++ b/src/hotspot/share/oops/methodData.cpp
@@ -1600,6 +1600,18 @@ bool MethodData::profile_unsafe(const methodHandle& m, int bci) {
   return false;
 }
 
+bool MethodData::profile_memory_access(const methodHandle& m, int bci) {
+  Bytecode_invoke inv(m , bci);
+  if (inv.is_invokestatic()) {
+    if (inv.klass() == vmSymbols::jdk_incubator_foreign_MemoryAccess()) {
+      if (inv.name()->starts_with("get") || inv.name()->starts_with("set")) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 int MethodData::profile_arguments_flag() {
   return TypeProfileLevel % 10;
 }
@@ -1626,6 +1638,10 @@ bool MethodData::profile_arguments_for_invoke(const methodHandle& m, int bci) {
   }
 
   if (profile_unsafe(m, bci)) {
+    return true;
+  }
+
+  if (profile_memory_access(m, bci)) {
     return true;
   }
 

--- a/src/hotspot/share/oops/methodData.hpp
+++ b/src/hotspot/share/oops/methodData.hpp
@@ -2148,6 +2148,7 @@ private:
 
   static bool profile_jsr292(const methodHandle& m, int bci);
   static bool profile_unsafe(const methodHandle& m, int bci);
+  static bool profile_memory_access(const methodHandle& m, int bci);
   static int profile_arguments_flag();
   static bool profile_all_arguments();
   static bool profile_arguments_for_invoke(const methodHandle& m, int bci);

--- a/src/java.base/share/classes/jdk/internal/access/foreign/MemorySegmentProxy.java
+++ b/src/java.base/share/classes/jdk/internal/access/foreign/MemorySegmentProxy.java
@@ -32,18 +32,18 @@ import jdk.internal.misc.ScopedMemoryAccess;
  * This proxy interface is required to allow instances of the {@code MemorySegment} interface (which is defined inside
  * an incubating module) to be accessed from the memory access var handles.
  */
-public interface MemorySegmentProxy {
+public abstract class MemorySegmentProxy {
     /**
      * Check that memory access is within spatial bounds and that access is compatible with segment access modes.
      * @throws UnsupportedOperationException if underlying segment has incompatible access modes (e.g. attempting to write
      * a read-only segment).
      * @throws IndexOutOfBoundsException if access is out-of-bounds.
      */
-    void checkAccess(long offset, long length, boolean readOnly);
-    long unsafeGetOffset();
-    Object unsafeGetBase();
-    boolean isSmall();
-    ScopedMemoryAccess.Scope scope();
+    public abstract void checkAccess(long offset, long length, boolean readOnly);
+    public abstract long unsafeGetOffset();
+    public abstract Object unsafeGetBase();
+    public abstract boolean isSmall();
+    public abstract ScopedMemoryAccess.Scope scope();
 
     /* Helper functions for offset computations. These are required so that we can avoid issuing long opcodes
      * (e.g. LMUL, LADD) when we're operating on 'small' segments (segments whose length can be expressed with an int).
@@ -51,7 +51,7 @@ public interface MemorySegmentProxy {
      * BCE when working with small segments. This workaround should be dropped when JDK-8223051 is resolved.
      */
 
-    static long addOffsets(long op1, long op2, MemorySegmentProxy segmentProxy) {
+    public static long addOffsets(long op1, long op2, MemorySegmentProxy segmentProxy) {
         if (segmentProxy.isSmall()) {
             // force ints for BCE
             if (op1 > Integer.MAX_VALUE || op2 > Integer.MAX_VALUE
@@ -74,7 +74,7 @@ public interface MemorySegmentProxy {
         }
     }
 
-    static long multiplyOffsets(long op1, long op2, MemorySegmentProxy segmentProxy) {
+    public static long multiplyOffsets(long op1, long op2, MemorySegmentProxy segmentProxy) {
         if (segmentProxy.isSmall()) {
             if (op1 > Integer.MAX_VALUE || op2 > Integer.MAX_VALUE
                     || op1 < Integer.MIN_VALUE || op2 < Integer.MIN_VALUE) {

--- a/src/java.base/share/classes/jdk/internal/access/foreign/MemorySegmentProxy.java
+++ b/src/java.base/share/classes/jdk/internal/access/foreign/MemorySegmentProxy.java
@@ -29,7 +29,7 @@ package jdk.internal.access.foreign;
 import jdk.internal.misc.ScopedMemoryAccess;
 
 /**
- * This proxy interface is required to allow instances of the {@code MemorySegment} interface (which is defined inside
+ * This abstract class is required to allow implementations of the {@code MemorySegment} interface (which is defined inside
  * an incubating module) to be accessed from the memory access var handles.
  */
 public abstract class MemorySegmentProxy {

--- a/src/java.base/share/classes/jdk/internal/misc/X-ScopedMemoryAccess.java.template
+++ b/src/java.base/share/classes/jdk/internal/misc/X-ScopedMemoryAccess.java.template
@@ -325,3 +325,6 @@ public class ScopedMemoryAccess {
     }
     // typed-ops here
 
+    // Note: all the accessor methods defined below take advantage of argument type profiling
+    // (see src/hotspot/share/oops/methodData.cpp) which greatly enhances performance when the same accessor
+    // method is used repeatedly with different 'base' objects.

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAccess.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAccess.java
@@ -88,6 +88,10 @@ public final class MemoryAccess {
         return MemoryHandles.varHandle(carrier, 1, elementLayout.order());
     }
 
+    // Note: all the accessor methods defined below take advantage of argument type profiling
+    // (see src/hotspot/share/oops/methodData.cpp) which greatly enhances performance when the same accessor
+    // method is used repeatedly with different segment kinds (e.g. on-heap vs. off-heap).
+
     /**
      * Reads a byte from given segment and offset.
      *

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -53,7 +53,7 @@ import java.util.function.IntFunction;
  * are defined for each memory segment kind, see {@link NativeMemorySegmentImpl}, {@link HeapMemorySegmentImpl} and
  * {@link MappedMemorySegmentImpl}.
  */
-public abstract class AbstractMemorySegmentImpl implements MemorySegment, MemorySegmentProxy {
+public abstract class AbstractMemorySegmentImpl extends MemorySegmentProxy implements MemorySegment {
 
     private static final ScopedMemoryAccess SCOPED_MEMORY_ACCESS = ScopedMemoryAccess.getScopedMemoryAccess();
 

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverPollutedSegments.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverPollutedSegments.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.jdk.incubator.foreign;
+
+import jdk.incubator.foreign.MemoryAccess;
+import jdk.incubator.foreign.MemoryLayout;
+import jdk.incubator.foreign.MemorySegment;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import sun.misc.Unsafe;
+
+import java.lang.invoke.VarHandle;
+import java.util.concurrent.TimeUnit;
+
+import static jdk.incubator.foreign.MemoryLayout.PathElement.sequenceElement;
+import static jdk.incubator.foreign.MemoryLayouts.JAVA_INT;
+
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@State(org.openjdk.jmh.annotations.Scope.Thread)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(value = 3, jvmArgsAppend = { "--add-modules=jdk.incubator.foreign" })
+public class LoopOverPollutedSegments {
+
+    static final int ELEM_SIZE = 1_000_000;
+    static final int CARRIER_SIZE = (int) JAVA_INT.byteSize();
+    static final int ALLOC_SIZE = ELEM_SIZE * CARRIER_SIZE;
+
+    static final Unsafe unsafe = Utils.unsafe;
+
+    MemorySegment nativeSegment, heapSegmentBytes, heapSegmentFloats;
+    byte[] arr;
+    long addr;
+
+    static final VarHandle intHandle = MemoryLayout.ofSequence(JAVA_INT).varHandle(int.class, MemoryLayout.PathElement.sequenceElement());
+
+
+    @Setup
+    public void setup() {
+        addr = unsafe.allocateMemory(ALLOC_SIZE);
+        for (int i = 0; i < ELEM_SIZE; i++) {
+            unsafe.putInt(addr + (i * 4), i);
+        }
+        arr = new byte[ALLOC_SIZE];
+        nativeSegment = MemorySegment.allocateNative(ALLOC_SIZE, 4);
+        heapSegmentBytes = MemorySegment.ofArray(new byte[ALLOC_SIZE]);
+        heapSegmentFloats = MemorySegment.ofArray(new float[ELEM_SIZE]);
+
+        for (int rep = 0 ; rep < 5 ; rep++) {
+            for (int i = 0; i < ELEM_SIZE; i++) {
+                unsafe.putInt(arr, Unsafe.ARRAY_BYTE_BASE_OFFSET + (i * 4), i);
+                MemoryAccess.setIntAtIndex(nativeSegment, i, i);
+                MemoryAccess.setFloatAtIndex(nativeSegment, i, i);
+                intHandle.set(nativeSegment, (long)i, i);
+                MemoryAccess.setIntAtIndex(heapSegmentBytes, i, i);
+                MemoryAccess.setFloatAtIndex(heapSegmentBytes, i, i);
+                intHandle.set(heapSegmentBytes, (long)i, i);
+                MemoryAccess.setIntAtIndex(heapSegmentFloats, i, i);
+                MemoryAccess.setFloatAtIndex(heapSegmentFloats, i, i);
+                intHandle.set(heapSegmentFloats, (long)i, i);
+            }
+        }
+    }
+
+    @TearDown
+    public void tearDown() {
+        nativeSegment.close();
+        heapSegmentBytes = null;
+        heapSegmentFloats = null;
+        arr = null;
+        unsafe.freeMemory(addr);
+    }
+
+    @Benchmark
+    public int native_segment_VH() {
+        int sum = 0;
+        for (int k = 0; k < ELEM_SIZE; k++) {
+            intHandle.set(nativeSegment, (long)k, k + 1);
+            int v = (int) intHandle.get(nativeSegment, (long)k);
+            sum += v;
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public int native_segment_static() {
+        int sum = 0;
+        for (int k = 0; k < ELEM_SIZE; k++) {
+            MemoryAccess.setIntAtOffset(nativeSegment, k, k + 1);
+            int v = MemoryAccess.getIntAtOffset(nativeSegment, k);
+            sum += v;
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public int heap_segment_ints_VH() {
+        int sum = 0;
+        for (int k = 0; k < ELEM_SIZE; k++) {
+            intHandle.set(heapSegmentBytes, (long)k, k + 1);
+            int v = (int) intHandle.get(heapSegmentBytes, (long)k);
+            sum += v;
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public int heap_segment_ints_static() {
+        int sum = 0;
+        for (int k = 0; k < ELEM_SIZE; k++) {
+            MemoryAccess.setIntAtOffset(heapSegmentBytes, k, k + 1);
+            int v = MemoryAccess.getIntAtOffset(heapSegmentBytes, k);
+            sum += v;
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public int heap_segment_floats_VH() {
+        int sum = 0;
+        for (int k = 0; k < ELEM_SIZE; k++) {
+            intHandle.set(heapSegmentFloats, (long)k, k + 1);
+            int v = (int)intHandle.get(heapSegmentFloats, (long)k);
+            sum += v;
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public int heap_segment_floats_static() {
+        int sum = 0;
+        for (int k = 0; k < ELEM_SIZE; k++) {
+            MemoryAccess.setIntAtOffset(heapSegmentFloats, k, k + 1);
+            int v = MemoryAccess.getIntAtOffset(heapSegmentFloats, k);
+            sum += v;
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public int heap_unsafe() {
+        int sum = 0;
+        for (int k = 0; k < ALLOC_SIZE; k += 4) {
+            unsafe.putInt(arr, k + Unsafe.ARRAY_BYTE_BASE_OFFSET, k + 1);
+            int v = unsafe.getInt(arr, k + Unsafe.ARRAY_BYTE_BASE_OFFSET);
+            sum += v;
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public int native_unsafe() {
+        int sum = 0;
+        for (int k = 0; k < ALLOC_SIZE; k += 4) {
+            unsafe.putInt(addr + k, k + 1);
+            int v = unsafe.getInt(addr + k);
+            sum += v;
+        }
+        return sum;
+    }
+}


### PR DESCRIPTION
This patch fixes a problem with type profile pollution when segments of different kinds are used on the same memory access var handle, or on the same `MemoryAccess` static method.

In principle, argument profiling should kick in for VarHandles and MethodHandles, and that should be enough at least to avoid pollution when using var handles directly. In reality, this is not the case; as Vlad discovered after relatively intense debugging session (thanks!), the VarHandle implementation code has to cast the incoming segment to the `MemorySegmentProxy` internal interface. This creates problems for C2, as concrete segment implementations have _two_ interface types: `MemorySegment` and the internal `MemorySegmentProxy` class. Side casts from one to the other are not supported well, and can cause loss of type profiling infomation.

To solve this problem we realized, in hindisght, that `MemorySegmentProxy` didn't really needed to be an interface and that it could easily be converted to an abstract class. Alone this solves 50% of the issues, since that makes direct var handle access robust to pollution issues. The remaining problems (using accessors in `MemoryAccess` class) can be addressed the usual way, by adding argument type profiling for the methods in that class (similarly to what we've done for `ScopedMemoryAccess`).

Here are some numbers before the patch:

```
Benchmark                                            Mode  Cnt   Score   Error  Units
LoopOverPollutedSegments.heap_segment_floats_VH      avgt   30  11.535 ? 0.039  ms/op
LoopOverPollutedSegments.heap_segment_floats_static  avgt   30  10.860 ? 0.162  ms/op
LoopOverPollutedSegments.heap_segment_ints_VH        avgt   30  11.479 ? 0.202  ms/op
LoopOverPollutedSegments.heap_segment_ints_static    avgt   30  10.562 ? 0.027  ms/op
LoopOverPollutedSegments.heap_unsafe                 avgt   30   0.240 ? 0.003  ms/op
LoopOverPollutedSegments.native_segment_VH           avgt   30  11.603 ? 0.154  ms/op
LoopOverPollutedSegments.native_segment_static       avgt   30  10.613 ? 0.128  ms/op
LoopOverPollutedSegments.native_unsafe               avgt   30   0.243 ? 0.003  ms/op
```

As you can see there is quite a big difference between unsafe access and all the other modes. Here are the results after the patch:

```
Benchmark                                            Mode  Cnt  Score   Error  Units
LoopOverPollutedSegments.heap_segment_floats_VH      avgt   30  0.244 ? 0.002  ms/op
LoopOverPollutedSegments.heap_segment_floats_static  avgt   30  0.301 ? 0.001  ms/op
LoopOverPollutedSegments.heap_segment_ints_VH        avgt   30  0.245 ? 0.003  ms/op
LoopOverPollutedSegments.heap_segment_ints_static    avgt   30  0.302 ? 0.004  ms/op
LoopOverPollutedSegments.heap_unsafe                 avgt   30  0.242 ? 0.003  ms/op
LoopOverPollutedSegments.native_segment_VH           avgt   30  0.246 ? 0.004  ms/op
LoopOverPollutedSegments.native_segment_static       avgt   30  0.295 ? 0.006  ms/op
LoopOverPollutedSegments.native_unsafe               avgt   30  0.245 ? 0.003  ms/op
```

That is, the situation is back to normal. Thanks to @JornVernee and @iwanowww for the help!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258242](https://bugs.openjdk.java.net/browse/JDK-8258242): Type profile pollution occurs when memory segments of different kinds are used


### Reviewers
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**) ⚠️ Review applies to 324d5b925fe9a3443389c3cbe984dcbc595f0413
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/19/head:pull/19`
`$ git checkout pull/19`
