### PR TITLE
8255763: C2: OSR miscompilation caused by invalid memory instruction placement

### DIFF
--- a/src/hotspot/share/opto/block.cpp
+++ b/src/hotspot/share/opto/block.cpp
@@ -1226,7 +1226,7 @@ void PhaseCFG::verify() const {
       // of L. This is guaranteed by the freq. estimation model for reducible
       // CFGs, and by special handling in PhaseCFG::schedule_late() otherwise.
       if (n->is_Mach() && n->bottom_type()->has_memory() && n->in(0) != NULL) {
-        Block *original_block = find_block_for_node(n->in(0));
+        Block* original_block = find_block_for_node(n->in(0));
         assert(original_block != NULL, "missing block for memory-writing node");
         CFGLoop* original_or_ancestor = original_block->_loop;
         assert(block->_loop != NULL && original_or_ancestor != NULL, "no loop");

--- a/src/hotspot/share/opto/block.cpp
+++ b/src/hotspot/share/opto/block.cpp
@@ -1221,6 +1221,26 @@ void PhaseCFG::verify() const {
       if (j >= 1 && n->is_Mach() && n->as_Mach()->ideal_Opcode() == Op_CreateEx) {
         assert(j == 1 || block->get_node(j-1)->is_Phi(), "CreateEx must be first instruction in block");
       }
+      // Verify that memory-writing nodes (such as stores and calls) are placed
+      // in their original loop L (given by the control input) or in an ancestor
+      // of L. This is guaranteed by the freq. estimation model for reducible
+      // CFGs, and by special handling in PhaseCFG::schedule_late() otherwise.
+      if (n->is_Mach() && n->bottom_type()->has_memory() && n->in(0) != NULL) {
+        Block *original_block = find_block_for_node(n->in(0));
+        assert(original_block != NULL, "missing block for memory-writing node");
+        CFGLoop* original_or_ancestor = original_block->_loop;
+        assert(block->_loop != NULL && original_or_ancestor != NULL, "no loop");
+        bool found = false;
+        do {
+          if (block->_loop == original_or_ancestor) {
+            found = true;
+            break;
+          }
+          original_or_ancestor = original_or_ancestor->parent();
+        } while (original_or_ancestor != NULL);
+        assert(found, "memory-writing node is not placed in its original loop "
+                      "or an ancestor of it");
+      }
       if (n->needs_anti_dependence_check()) {
         verify_anti_dependences(block, n);
       }

--- a/src/hotspot/share/opto/block.hpp
+++ b/src/hotspot/share/opto/block.hpp
@@ -501,8 +501,8 @@ class PhaseCFG : public Phase {
   CFGLoop* create_loop_tree();
   bool is_dominator(Node* dom_node, Node* node);
   bool is_CFG(Node* n);
-  bool is_control_proj_or_safepoint(Node* n);
-  Block* find_block_for_node(Node* n);
+  bool is_control_proj_or_safepoint(Node* n) const;
+  Block* find_block_for_node(Node* n) const;
   bool is_dominating_control(Node* dom_ctrl, Node* n);
   #ifndef PRODUCT
   bool _trace_opto_pipelining;  // tracing flag

--- a/test/hotspot/jtreg/compiler/codegen/TestGCMStorePlacement.java
+++ b/test/hotspot/jtreg/compiler/codegen/TestGCMStorePlacement.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.codegen;
+
+import jdk.test.lib.Asserts;
+
+/**
+ * @test
+ * @bug 8255763
+ * @summary Tests GCM's store placement for reducible and irreducible CFGs.
+ * @library /test/lib /
+ * @run main/othervm -Xbatch compiler.codegen.TestGCMStorePlacement reducible
+ * @run main/othervm -Xbatch compiler.codegen.TestGCMStorePlacement irreducible
+ */
+
+public class TestGCMStorePlacement {
+
+    static int counter;
+
+    // Reducible case: counter++ should not be placed into the loop.
+    static void testReducible() {
+        counter++;
+        int acc = 0;
+        for (int i = 0; i < 50; i++) {
+            if (i % 2 == 0) {
+                acc += 1;
+            }
+        }
+        return;
+    }
+
+    // Irreducible case (due to OSR compilation): counter++ should not be placed
+    // outside its switch case block.
+    static void testIrreducible() {
+        for (int i = 0; i < 30; i++) {
+            switch (i % 3) {
+            case 0:
+                for (int j = 0; j < 50; j++) {
+                    // OSR enters here.
+                    for (int k = 0; k < 7000; k++) {}
+                    if (i % 2 == 0) {
+                        break;
+                    }
+                }
+                counter++;
+                break;
+            case 1:
+                break;
+            case 2:
+                break;
+            }
+        }
+        return;
+    }
+
+    public static void main(String[] args) {
+        switch (args[0]) {
+        case "reducible":
+            // Cause a regular C2 compilation of testReducible.
+            for (int i = 0; i < 100_000; i++) {
+                counter = 0;
+                testReducible();
+                Asserts.assertEQ(counter, 1);
+            }
+            break;
+        case "irreducible":
+            // Cause an OSR C2 compilation of testIrreducible.
+            counter = 0;
+            testIrreducible();
+            Asserts.assertEQ(counter, 10);
+            break;
+        default:
+            System.out.println("invalid mode");
+        }
+    }
+}


### PR DESCRIPTION
Disable GCM hoisting of memory-writing nodes for irreducible CFGs. This prevents GCM from wrongly "hoisting" stores into descendants of their original loop. Such an "inverted hoisting" can happen due to `CFGLoop::compute_freq()`'s inaccurate estimation of frequencies for irreducible CFGs.

Extend CFG verification code by checking that memory-writing nodes are placed in either their original loop or an ancestor.

Add tests for the reducible and irreducible cases. The former was already handled correctly before the change (the frequency estimation model prevents "inverted hoisting" for reducible CFGs), and is just added for coverage.

This change addresses the specific miscompilation issue in a conservative way, for simplicity and safety. Future work includes investigating if only the illegal blocks can be discarded as candidates for GCM hoisting, and refining frequency estimation for irreducible CFGs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255763](https://bugs.openjdk.java.net/browse/JDK-8255763): C2: OSR miscompilation caused by invalid memory instruction placement


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to 622299c3f2cc4934554f3ed4988418d2b16581d5
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/22/head:pull/22`
`$ git checkout pull/22`
