### PR TITLE
8258404: Restore stacktrace reuse after 8258094

### DIFF
--- a/src/hotspot/share/jfr/support/jfrAllocationTracer.cpp
+++ b/src/hotspot/share/jfr/support/jfrAllocationTracer.cpp
@@ -30,11 +30,12 @@
 #include "runtime/thread.hpp"
 
 JfrAllocationTracer::JfrAllocationTracer(const Klass* klass, HeapWord* obj, size_t alloc_size, bool outside_tlab, Thread* thread) : _tl(NULL) {
-  JfrObjectAllocationSample::send_event(klass, alloc_size, outside_tlab, thread);
   if (LeakProfiler::is_running()) {
     _tl = thread->jfr_thread_local();
     LeakProfiler::sample(obj, alloc_size, thread->as_Java_thread());
   }
+  // Let this happen after LeakProfiler::sample, to possibly reuse a cached stacktrace.
+  JfrObjectAllocationSample::send_event(klass, alloc_size, outside_tlab, thread);
 }
 
 JfrAllocationTracer::~JfrAllocationTracer() {


### PR DESCRIPTION
Greetings,

a tiny adjustment to restore the possibility of capitalizing on a cached stacktrace.

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258404](https://bugs.openjdk.java.net/browse/JDK-8258404): Restore stacktrace reuse after 8258094


### Reviewers
 * [Erik Gahlin](https://openjdk.java.net/census#egahlin) (@egahlin - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/23/head:pull/23`
`$ git checkout pull/23`
