### PR TITLE
8256843: [PPC64] runtime/logging/RedefineClasses.java fails with assert: registers not saved on stack

### DIFF
--- a/src/hotspot/os_cpu/aix_ppc/os_aix_ppc.cpp
+++ b/src/hotspot/os_cpu/aix_ppc/os_aix_ppc.cpp
@@ -65,16 +65,7 @@
 # include <ucontext.h>
 
 address os::current_stack_pointer() {
-  address csp;
-
-#if !defined(USE_XLC_BUILTINS)
-  // inline assembly for `mr regno(csp), R1_SP':
-  __asm__ __volatile__ ("mr %0, 1":"=r"(csp):);
-#else
-  csp = (address) __builtin_frame_address(0);
-#endif
-
-  return csp;
+  return (address)__builtin_frame_address(0);
 }
 
 char* os::non_memory_address_word() {
@@ -159,13 +150,9 @@ frame os::get_sender_for_C_frame(frame* fr) {
 
 
 frame os::current_frame() {
-  intptr_t* csp = (intptr_t*) *((intptr_t*) os::current_stack_pointer());
-  // hack.
-  frame topframe(csp, (address)0x8);
-  // Return sender of sender of current topframe which hopefully
-  // both have pc != NULL.
-  frame tmp = os::get_sender_for_C_frame(&topframe);
-  return os::get_sender_for_C_frame(&tmp);
+  intptr_t* csp = *(intptr_t**) __builtin_frame_address(0);
+  frame topframe(csp, CAST_FROM_FN_PTR(address, os::current_frame));
+  return os::get_sender_for_C_frame(&topframe);
 }
 
 bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,

--- a/src/hotspot/share/utilities/nativeCallStack.cpp
+++ b/src/hotspot/share/utilities/nativeCallStack.cpp
@@ -36,7 +36,7 @@ NativeCallStack::NativeCallStack(int toSkip, bool fillStack) :
     // to call os::get_native_stack. A tail call is used if _NMT_NOINLINE_ is not defined
     // (which means this is not a slowdebug build), and we are on 64-bit (except Windows).
     // This is not necessarily a rule, but what has been obvserved to date.
-#if (defined(_NMT_NOINLINE_) || defined(_WINDOWS) || !defined(_LP64))
+#if (defined(_NMT_NOINLINE_) || defined(_WINDOWS) || !defined(_LP64) || defined(PPC64))
     // Not a tail call.
     toSkip++;
 #if (defined(_NMT_NOINLINE_) && defined(BSD) && defined(_LP64))


### PR DESCRIPTION
// Continuation of https://github.com/openjdk/jdk/pull/1724
// I'm taking over from @TheRealMDoerr who's busy with 11u downports

Please help review this small PPC64 fix.
It replaces the call os::current_stack_pointer() in os::current_frame()
with __builtin_frame_address(0) which is available also with xlC used by the AIX
build. With this os::current_frame() is agnostic to C++ compiler inlining.

Furthermore the fix changes os::current_frame() to return the correct
frame. Without the fix the returned frame is one frame to high which triggered
the assertion in trace_method_handle_stub().
This change uncovers an issue with NativeCallStack::NativeCallStack(int toSkip, bool fillStack)
on PPC64. There the call os::get_native_stack() is not compiled
to a tail call therefore the frame of the NativeCallStack constructor needs to
be skipped on PPC64 too as on other platforms.

Without this

make run-test TEST=test/hotspot/jtreg/runtime/NMT/CheckForProperDetailStackTrace.java

fails.

Furthermore the inline assembler from os::current_stack_pointer() is
removed. Instead __builtin_frame_address(0) is used again.

The fix passed our CI testing: JCK and JTREG, also in Xcomp mode, SPECjvm2008, SPECjbb2015, Renaissance Suite,
SAP specific tests with fastdebug and release builds on all platforms

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8256843](https://bugs.openjdk.java.net/browse/JDK-8256843): [PPC64] runtime/logging/RedefineClasses.java fails with assert: registers not saved on stack


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.java.net/census#lucy) (@RealLucy - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/24/head:pull/24`
`$ git checkout pull/24`
