### PR TITLE
JDK-8258338: Support deprecated records

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/DeprecatedListWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/DeprecatedListWriter.java
@@ -95,6 +95,8 @@ public class DeprecatedListWriter extends SubWriterHolderWriter {
                 return "enum.constant";
             case ANNOTATION_TYPE_MEMBER:
                 return "annotation.type.member";
+            case RECORD_CLASS:
+                return "record.class";
             default:
                 throw new AssertionError("unknown kind: " + kind);
         }
@@ -120,6 +122,8 @@ public class DeprecatedListWriter extends SubWriterHolderWriter {
                 return "doclet.Errors";
             case ANNOTATION_TYPE:
                 return "doclet.Annotation_Types";
+            case RECORD_CLASS:
+                return "doclet.RecordClasses";
             case FIELD:
                 return "doclet.Fields";
             case METHOD:
@@ -155,6 +159,8 @@ public class DeprecatedListWriter extends SubWriterHolderWriter {
                 return "doclet.errors";
             case ANNOTATION_TYPE:
                 return "doclet.annotation_types";
+            case RECORD_CLASS:
+                return "doclet.record_classes";
             case FIELD:
                 return "doclet.fields";
             case METHOD:
@@ -190,6 +196,8 @@ public class DeprecatedListWriter extends SubWriterHolderWriter {
                 return "doclet.Errors";
             case ANNOTATION_TYPE:
                 return "doclet.AnnotationType";
+            case RECORD_CLASS:
+                return "doclet.Record";
             case FIELD:
                 return "doclet.Field";
             case METHOD:
@@ -229,6 +237,7 @@ public class DeprecatedListWriter extends SubWriterHolderWriter {
                 case EXCEPTION:
                 case ERROR:
                 case ANNOTATION_TYPE:
+                case RECORD_CLASS:
                     writerMap.put(kind, classW);
                     break;
                 case FIELD:
@@ -407,6 +416,7 @@ public class DeprecatedListWriter extends SubWriterHolderWriter {
             case CLASS:
             case ENUM:
             case ANNOTATION_TYPE:
+            case RECORD:
                 writer = new NestedClassWriterImpl(this);
                 break;
             case FIELD:

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/standard.properties
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/standard.properties
@@ -99,6 +99,7 @@ doclet.Annotation_Type_Members=Annotation Type Elements
 doclet.for_removal=for removal
 doclet.annotation_types=annotation types
 doclet.annotation_type_members=annotation type elements
+doclet.record_classes=record classes
 doclet.Generated_Docs_Untitled=Generated Documentation (Untitled)
 doclet.Other_Packages=Other Packages
 doclet.Description=Description

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/doclets.properties
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/doclets.properties
@@ -142,6 +142,7 @@ doclet.Method_Summary=Method Summary
 doclet.Record_Summary=Record Summary
 doclet.Interfaces=Interfaces
 doclet.Enums=Enums
+doclet.RecordClasses=Record Classes
 doclet.AnnotationTypes=Annotation Types
 doclet.Exceptions=Exceptions
 doclet.Errors=Errors

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/DeprecatedAPIListBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/DeprecatedAPIListBuilder.java
@@ -59,6 +59,7 @@ public class DeprecatedAPIListBuilder {
         ENUM,
         EXCEPTION,              // no ElementKind mapping
         ERROR,                  // no ElementKind mapping
+        RECORD_CLASS,
         ANNOTATION_TYPE,
         FIELD,
         METHOD,
@@ -142,6 +143,10 @@ public class DeprecatedAPIListBuilder {
                         break;
                     case ENUM:
                         eset = deprecatedMap.get(DeprElementKind.ENUM);
+                        eset.add(e);
+                        break;
+                    case RECORD:
+                        eset = deprecatedMap.get(DeprElementKind.RECORD_CLASS);
                         eset.add(e);
                         break;
                 }

--- a/test/langtools/jdk/javadoc/doclet/testRecordTypes/TestRecordTypes.java
+++ b/test/langtools/jdk/javadoc/doclet/testRecordTypes/TestRecordTypes.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug      8225055 8239804 8246774
+ * @bug      8225055 8239804 8246774 8258338
  * @summary  Record types
  * @library  /tools/lib ../../lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool
@@ -493,5 +493,71 @@ public class TestRecordTypes extends JavadocTester {
                             <span class="modifiers">public</span>&nbsp;<span class="return-type">int</span>&\
                             nbsp;<span class="element-name">i</span>()</div>""");
 
+    }
+
+    @Test
+    public void testDeprecatedRecord(Path base) throws IOException {
+        Path src = base.resolve("src");
+        tb.writeJavaFiles(src,
+                """
+                    package p; /** This is record R.
+                     * @deprecated Do not use.
+                     */
+                    @Deprecated
+                    public record R(int r1) { }""");
+
+        javadoc("-d", base.resolve("out").toString(),
+                "-quiet", "-noindex",
+                "-sourcepath", src.toString(),
+                "p");
+        checkExit(Exit.OK);
+
+        checkOutput("deprecated-list.html", true,
+                """
+                    <h2 title="Contents">Contents</h2>
+                    <ul>
+                    <li><a href="#record.class">Record Classes</a></li>
+                    </ul>""",
+                """
+                    <div id="record.class">
+                    <div class="caption"><span>Record Classes</span></div>
+                    <div class="summary-table two-column-summary">
+                    <div class="table-header col-first">Record</div>
+                    <div class="table-header col-last">Description</div>
+                    <div class="col-deprecated-item-name even-row-color"><a href="p/R.html" title="class in p">p.R</a></div>
+                    <div class="col-last even-row-color">
+                    <div class="deprecation-comment">Do not use.</div>
+                    </div>""");
+    }
+
+    @Test
+    public void testDeprecatedRecordComponent(Path base) throws IOException {
+        Path src = base.resolve("src");
+        tb.writeJavaFiles(src,
+                """
+                    package p; /** This is record R. */
+                    public record R(@Deprecated int r1) { }""");
+
+        javadoc("-d", base.resolve("out").toString(),
+                "-quiet", "-noindex",
+                "-sourcepath", src.toString(),
+                "p");
+        checkExit(Exit.OK);
+
+        checkOutput("deprecated-list.html", true,
+                """
+                    <h2 title="Contents">Contents</h2>
+                    <ul>
+                    <li><a href="#method">Methods</a></li>
+                    </ul>""",
+                """
+                    <div id="method">
+                    <div class="caption"><span>Methods</span></div>
+                    <div class="summary-table two-column-summary">
+                    <div class="table-header col-first">Method</div>
+                    <div class="table-header col-last">Description</div>
+                    <div class="col-deprecated-item-name even-row-color"><a href="p/R.html#r1()">p.R.r1()</a></div>
+                    <div class="col-last even-row-color"></div>
+                    </div>""");
     }
 }


### PR DESCRIPTION
Relatively simple update to fix an oversight in the support for records. `RECORD` was not added to `DeprElementKind` with the derivative downstream updates.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258338](https://bugs.openjdk.java.net/browse/JDK-8258338): Support deprecated records


### Reviewers
 * [Hannes Wallnöfer](https://openjdk.java.net/census#hannesw) (@hns - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/29/head:pull/29`
`$ git checkout pull/29`
