### PR TITLE
8258236: Segfault in ClassListParser::resolve_indy dumping static AppCDS archive

### DIFF
--- a/src/hotspot/share/classfile/classListParser.cpp
+++ b/src/hotspot/share/classfile/classListParser.cpp
@@ -467,6 +467,10 @@ void ClassListParser::resolve_indy(Symbol* class_name_symbol, TRAPS) {
   Klass* klass = SystemDictionary::resolve_or_fail(class_name_symbol, class_loader, protection_domain, true, THREAD); // FIXME should really be just a lookup
   if (klass != NULL && klass->is_instance_klass()) {
     InstanceKlass* ik = InstanceKlass::cast(klass);
+    if (SystemDictionaryShared::has_class_failed_verification(ik)) {
+      // don't attempt to resolve indy on classes that has previously failed verification
+      return;
+    }
     MetaspaceShared::try_link_class(ik, THREAD);
     assert(!HAS_PENDING_EXCEPTION, "unexpected exception");
 

--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -336,6 +336,7 @@ hotspot_appcds_dynamic = \
  -runtime/cds/appcds/ExtraSymbols.java \
  -runtime/cds/appcds/LambdaEagerInit.java \
  -runtime/cds/appcds/LambdaProxyClasslist.java \
+ -runtime/cds/appcds/LambdaVerificationFailedDuringDump.java \
  -runtime/cds/appcds/LongClassListPath.java \
  -runtime/cds/appcds/LotsOfClasses.java \
  -runtime/cds/appcds/NonExistClasspath.java \

--- a/test/hotspot/jtreg/runtime/cds/appcds/LambdaVerificationFailedDuringDump.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/LambdaVerificationFailedDuringDump.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @summary Dumping of lambda proxy classes should not crash VM in case the caller class has failed verification.
+ * @requires vm.cds
+ * @library /test/lib
+ * @compile test-classes/BadInvokeDynamic.jcod
+ * @run driver LambdaVerificationFailedDuringDump
+ */
+
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class LambdaVerificationFailedDuringDump {
+
+    public static void main(String[] args) throws Exception {
+        JarBuilder.build("badinvokedynamic", "BadInvokeDynamic");
+
+        String appJar = TestCommon.getTestJar("badinvokedynamic.jar");
+
+        OutputAnalyzer out = TestCommon.dump(appJar,
+        TestCommon.list("BadInvokeDynamic",
+                        "@lambda-proxy BadInvokeDynamic run ()Ljava/lang/Runnable; ()V REF_invokeStatic BadInvokeDynamic lambda$doTest$0 ()V ()V"));
+        out.shouldContain("Preload Warning: Verification failed for BadInvokeDynamic")
+           .shouldContain("Skipping BadInvokeDynamic: Failed verification")
+           .shouldHaveExitValue(0);
+    }
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/test-classes/BadInvokeDynamic.jcod
+++ b/test/hotspot/jtreg/runtime/cds/appcds/test-classes/BadInvokeDynamic.jcod
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+// Should get a verifier error at bytecode 15 for JVM_CONSTANT_NameAndType
+
+class BadInvokeDynamic {
+  0xCAFEBABE;
+  0; // minor version
+  51; // version
+  [] { // Constant Pool
+    ; // first element is empty
+    Method #6 #15; // #1
+    Field #16 #17; // #2
+    String #18; // #3
+    Method #19 #20; // #4
+    class #21; // #5
+    class #22; // #6
+    Utf8 "hello"; // #7
+    Utf8 "()V"; // #8
+    Utf8 "Code"; // #9
+    Utf8 "LineNumberTable"; // #10
+    Utf8 "main"; // #11
+    Utf8 "([Ljava/lang/String;)V"; // #12
+    Utf8 "SourceFile"; // #13
+    Utf8 "BadInvokeDynamic.java"; // #14
+    NameAndType #7 #8; // #15
+    class #23; // #16
+    NameAndType #24 #25; // #17
+    Utf8 "Hello World"; // #18
+    class #26; // #19
+    NameAndType #27 #28; // #20
+    Utf8 "BadInvokeDynamic"; // #21
+    Utf8 "java/lang/Object"; // #22
+    Utf8 "java/lang/System"; // #23
+    Utf8 "out"; // #24
+    Utf8 "Ljava/io/PrintStream;"; // #25
+    Utf8 "java/io/PrintStream"; // #26
+    Utf8 "println"; // #27
+    Utf8 "(Ljava/lang/String;)V"; // #28
+  } // Constant Pool
+
+  0x0021; // access
+  #5;// this_cpx
+  #6;// super_cpx
+
+  [] { // Interfaces
+  } // Interfaces
+
+  [] { // fields
+  } // fields
+
+  [] { // methods
+    { // Member
+      0x0001; // access
+      #7; // name_cpx
+      #8; // sig_cpx
+      [] { // Attributes
+        Attr(#9) { // Code
+          1; // max_stack
+          1; // max_locals
+          Bytes[]{
+            0x2AB70001B1;
+          };
+          [] { // Traps
+          } // end Traps
+          [] { // Attributes
+            Attr(#10) { // LineNumberTable
+              [] { // LineNumberTable
+                0  1;
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    } // Member
+    ;
+    { // Member
+      0x0009; // access
+      #11; // name_cpx
+      #12; // sig_cpx
+      [] { // Attributes
+        Attr(#9) { // Code
+          2; // max_stack
+          2; // max_locals
+          Bytes[]{
+            0xB200021203B60004;
+            0x033CBA000F840102;
+            0x840103840104B1;
+          };
+          [] { // Traps
+          } // end Traps
+          [] { // Attributes
+            Attr(#10) { // LineNumberTable
+              [] { // LineNumberTable
+                0  3;
+                8  4;
+                10  5;
+                13  6;
+                16  7;
+                19  8;
+                22  9;
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    } // Member
+  } // methods
+
+  [] { // Attributes
+    Attr(#13) { // SourceFile
+      #14;
+    } // end SourceFile
+  } // Attributes
+} // end class BadInvokeDynamic


### PR DESCRIPTION
Please review this change for JDK 16.

In ClassListParser::resolve_indy, if a class has previously failed verification, don't proceed with resolve indy for that class to avoid dereferencing a null cpcache pointer.

Passed tiers 1,2,3,4 tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258236](https://bugs.openjdk.java.net/browse/JDK-8258236): Segfault in ClassListParser::resolve_indy dumping static AppCDS archive


### Reviewers
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/30/head:pull/30`
`$ git checkout pull/30`
