### PR TITLE
8258293: tools/jpackage/share/RuntimePackageTest.java#id0 with RuntimePackageTest.testUsrInstallDir2

### DIFF
--- a/test/jdk/tools/jpackage/share/RuntimePackageTest.java
+++ b/test/jdk/tools/jpackage/share/RuntimePackageTest.java
@@ -126,7 +126,11 @@ public class RuntimePackageTest {
 
     private static Set<Path> listFiles(Path root) throws IOException {
         try (var files = Files.walk(root)) {
-            return files.map(root::relativize).collect(Collectors.toSet());
+            // Ignore files created by system prefs if any.
+            final Path prefsDir = Path.of(".systemPrefs");
+            return files.map(root::relativize)
+                    .filter(x -> !x.startsWith(prefsDir))
+                    .collect(Collectors.toSet());
         }
     }
 


### PR DESCRIPTION
Ignore files created by prefs subsystem when checking if source runtime contains the same files as packed runtime.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258293](https://bugs.openjdk.java.net/browse/JDK-8258293): tools/jpackage/share/RuntimePackageTest.java#id0 with RuntimePackageTest.testUsrInstallDir2


### Reviewers
 * [Alexander Matveev](https://openjdk.java.net/census#almatvee) (@sashamatveev - Committer)
 * [Andy Herrick](https://openjdk.java.net/census#herrick) (@andyherrick - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/31/head:pull/31`
`$ git checkout pull/31`
