### PR TITLE
JDK-8241353: NPE in ToolProvider.getSystemJavaCompiler

### DIFF
--- a/src/java.compiler/share/classes/javax/tools/ToolProvider.java
+++ b/src/java.compiler/share/classes/javax/tools/ToolProvider.java
@@ -27,7 +27,7 @@ package javax.tools;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-import java.util.Iterator;
+import java.util.Objects;
 import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
 
@@ -118,8 +118,7 @@ public class ToolProvider {
 
         try {
             ServiceLoader<T> sl = ServiceLoader.load(clazz, ClassLoader.getSystemClassLoader());
-            for (Iterator<T> iter = sl.iterator(); iter.hasNext(); ) {
-                T tool = iter.next();
+            for (T tool : sl) {
                 if (matches(tool, moduleName))
                     return tool;
             }
@@ -140,7 +139,7 @@ public class ToolProvider {
         PrivilegedAction<Boolean> pa = () -> {
             Module toolModule = tool.getClass().getModule();
             String toolModuleName = toolModule.getName();
-            return toolModuleName.equals(moduleName);
+            return Objects.equals(toolModuleName, moduleName);
         };
         return AccessController.doPrivileged(pa);
     }


### PR DESCRIPTION
Trivial fix to avoid NPE by using `Objects.equals` instead of direct `String.equals`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8241353](https://bugs.openjdk.java.net/browse/JDK-8241353): NPE in ToolProvider.getSystemJavaCompiler


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/32/head:pull/32`
`$ git checkout pull/32`
