### PR TITLE
8256693: getAnnotatedReceiverType parameterizes types too eagerly

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/AnnotatedParameterizedType.java
+++ b/src/java.base/share/classes/java/lang/reflect/AnnotatedParameterizedType.java
@@ -38,6 +38,10 @@ public interface AnnotatedParameterizedType extends AnnotatedType {
     /**
      * Returns the potentially annotated actual type arguments of this parameterized type.
      *
+     * <p>Note that in some cases, the returned array can be empty. This can occur
+     * if this annotated type represents a non-parameterized type nested within
+     * a parameterized type.
+     *
      * @return the potentially annotated actual type arguments of this parameterized type
      * @see ParameterizedType#getActualTypeArguments()
      */

--- a/src/java.base/share/classes/java/lang/reflect/Constructor.java
+++ b/src/java.base/share/classes/java/lang/reflect/Constructor.java
@@ -662,7 +662,7 @@ public final class Constructor<T> extends Executable {
                     getConstantPool(thisDeclClass),
                 this,
                 thisDeclClass,
-                resolveToOwnerType(enclosingClass),
+                parameterize(enclosingClass),
                 TypeAnnotation.TypeAnnotationTarget.METHOD_RECEIVER);
     }
 }

--- a/src/java.base/share/classes/java/lang/reflect/Executable.java
+++ b/src/java.base/share/classes/java/lang/reflect/Executable.java
@@ -699,8 +699,27 @@ public abstract class Executable extends AccessibleObject
                         getConstantPool(getDeclaringClass()),
                 this,
                 getDeclaringClass(),
-                resolveToOwnerType(getDeclaringClass()),
+                parameterize(getDeclaringClass()),
                 TypeAnnotation.TypeAnnotationTarget.METHOD_RECEIVER);
+    }
+
+    Type parameterize(Class<?> c) {
+        Class<?> ownerClass = c.getDeclaringClass();
+        TypeVariable<?>[] typeVars = c.getTypeParameters();
+
+        if (ownerClass == null) { // base case
+            if (typeVars.length == 0)
+                return c;
+            else
+                return ParameterizedTypeImpl.make(c, typeVars, null);
+        }
+
+        // Resolve owner
+        Type ownerType = parameterize(ownerClass);
+        if (ownerType instanceof Class<?> && typeVars.length == 0) // We have yet to encounter type parameters
+            return c;
+        else
+            return ParameterizedTypeImpl.make(c, typeVars, ownerType);
     }
 
     /**
@@ -752,25 +771,5 @@ public abstract class Executable extends AccessibleObject
                 getDeclaringClass(),
                 getGenericExceptionTypes(),
                 TypeAnnotation.TypeAnnotationTarget.THROWS);
-    }
-
-    static Type resolveToOwnerType(Class<?> c) {
-        TypeVariable<?>[] v = c.getTypeParameters();
-        Type o = resolveOwner(c);
-        Type t;
-        if (o != null || v.length > 0) {
-            t = ParameterizedTypeImpl.make(c, v, o);
-        } else {
-            t = c;
-        }
-        return t;
-    }
-
-    private static Type resolveOwner(Class<?> t) {
-        if (Modifier.isStatic(t.getModifiers()) || !(t.isLocalClass() || t.isMemberClass() || t.isAnonymousClass())) {
-            return null;
-        }
-        Class<?> d = t.getDeclaringClass();
-        return ParameterizedTypeImpl.make(d, d.getTypeParameters(), resolveOwner(d));
     }
 }

--- a/test/jdk/java/lang/annotation/typeAnnotations/GetAnnotatedReceiverType.java
+++ b/test/jdk/java/lang/annotation/typeAnnotations/GetAnnotatedReceiverType.java
@@ -26,10 +26,7 @@
  * @bug 8024915 8044629 8256693
  */
 
-import java.lang.reflect.AnnotatedType;
-import java.lang.reflect.Executable;
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
+import java.lang.reflect.*;
 
 public class GetAnnotatedReceiverType {
     public void method() {}
@@ -157,25 +154,25 @@ public class GetAnnotatedReceiverType {
         Inner4<?>.Inner5 instance5 = instance4.new Inner5();
         Inner4<?>.Inner5.Inner6 instance6 = instance5.new Inner6();
 
-        checkTypeOfGetType(instance4.getClass().getConstructors()[0], false,
+        checkAnnotatedReceiverType(instance4.getClass().getConstructors()[0], false,
                 "The type of .getAnnotatedReceiverType().getType() for this constructor should be");
-        checkTypeOfGetType(instance5.getClass().getConstructors()[0], true,
+        checkAnnotatedReceiverType(instance5.getClass().getConstructors()[0], true,
                 "The type of .getAnnotatedReceiverType().getType() for this constructor should be");
-        checkTypeOfGetType(instance6.getClass().getConstructors()[0], true,
+        checkAnnotatedReceiverType(instance6.getClass().getConstructors()[0], true,
                 "The type of .getAnnotatedReceiverType().getType() for this constructor should be");
-        checkTypeOfGetType(outer.getClass().getMethod("method0"), false,
+        checkAnnotatedReceiverType(outer.getClass().getMethod("method0"), false,
                 "The type of .getAnnotatedReceiverType().getType() for this method should be");
-        checkTypeOfGetType(instance4.getClass().getMethod("innerMethod4"), true,
+        checkAnnotatedReceiverType(instance4.getClass().getMethod("innerMethod4"), true,
                 "The type of .getAnnotatedReceiverType().getType() for this method should be");
-        checkTypeOfGetType(instance5.getClass().getMethod("innerMethod5"), true,
+        checkAnnotatedReceiverType(instance5.getClass().getMethod("innerMethod5"), true,
                 "The type of .getAnnotatedReceiverType().getType() for this method should be");
-        checkTypeOfGetType(instance2.getClass().getMethod("innerMethod2"), false,
+        checkAnnotatedReceiverType(instance2.getClass().getMethod("innerMethod2"), false,
                 "The type of .getAnnotatedReceiverType().getType() for this method should be");
-        checkTypeOfGetType(instance3.getClass().getMethod("innerMethod3"), false,
+        checkAnnotatedReceiverType(instance3.getClass().getMethod("innerMethod3"), false,
                 "The type of .getAnnotatedReceiverType().getType() for this method should be");
 
         Inner2.Inner3.Inner7<?> instance7 = instance3.new Inner7<String>();
-        checkTypeOfGetType(instance7.getClass().getMethod("innerMethod7"), true,
+        checkAnnotatedReceiverType(instance7.getClass().getMethod("innerMethod7"), true,
                 "The type of .getAnnotatedReceiverType().getType() for this method should be");
         recursiveCheckAnnotatedOwnerTypes(instance7.getClass().getMethod("innerMethod7").getAnnotatedReceiverType());
 
@@ -203,11 +200,27 @@ public class GetAnnotatedReceiverType {
         tests++;
     }
 
-    private static void checkTypeOfGetType(Executable e, boolean shouldBeParameterized, String msg) {
+    private static void checkAnnotatedReceiverType(Executable e, boolean shouldBeParameterized, String msg) {
         Type t = e.getAnnotatedReceiverType().getType();
         if (shouldBeParameterized != (t instanceof ParameterizedType)) {
             failures++;
             System.err.println(e + ", " + msg + " " + (shouldBeParameterized ? "ParameterizedType" : "Class") + ", found: " + t.getClass().getSimpleName());
+        }
+
+        // Test we can get the potentially empty annotated actual type arguments array
+        if (shouldBeParameterized) {
+            try {
+                ParameterizedType t1 = (ParameterizedType)t;
+                AnnotatedParameterizedType at1 = (AnnotatedParameterizedType)e.getAnnotatedReceiverType();
+
+                if (t1.getActualTypeArguments().length != at1.getAnnotatedActualTypeArguments().length) {
+                    System.err.println(t1 + "'s actual type arguments can't match " + at1);
+                    failures++;
+                }
+            } catch (ClassCastException cce) {
+                System.err.println("Couldn't get potentially empty actual type arguments: " + cce.getMessage());
+                failures++;
+            }
         }
         tests++;
     }

--- a/test/jdk/java/lang/annotation/typeAnnotations/GetAnnotatedReceiverType.java
+++ b/test/jdk/java/lang/annotation/typeAnnotations/GetAnnotatedReceiverType.java
@@ -106,6 +106,7 @@ public class GetAnnotatedReceiverType {
 
     private static int failures = 0;
     private static int tests = 0;
+    private static final int EXPECTED_TEST_CASES = 25;
 
     public static void main(String[] args) throws NoSuchMethodException {
         checkEmptyAT(GetAnnotatedReceiverType.class.getMethod("method"),
@@ -178,7 +179,7 @@ public class GetAnnotatedReceiverType {
 
         if (failures != 0)
             throw new RuntimeException("Test failed, see log for details");
-        else if (tests != 25)
+        else if (tests != EXPECTED_TEST_CASES)
             throw new RuntimeException("Not all cases ran, failing");
     }
 


### PR DESCRIPTION
The fix for JDK-8256693 too often produces a ParameterizedType as the result of getAnnotatedReceiverType().getType() . A ParameterizedType is necessary only when this type or any of its transitive owner types has type parameters, but should be avoided if this isn't the case.

This implementation recursively creates a chain of ParameterizedTypes starting from the outermost type that has type parameters.

See here for the now closed JDK 17 pr: https://github.com/openjdk/jdk/pull/1414

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8256693](https://bugs.openjdk.java.net/browse/JDK-8256693): getAnnotatedReceiverType parameterizes types too eagerly


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/33/head:pull/33`
`$ git checkout pull/33`
