### PR TITLE
8257999: Parallel GC crash in gc/parallel/TestDynShrinkHeap.java: new region is not in covered_region

### DIFF
--- a/src/hotspot/share/gc/parallel/psOldGen.cpp
+++ b/src/hotspot/share/gc/parallel/psOldGen.cpp
@@ -35,6 +35,7 @@
 #include "logging/log.hpp"
 #include "oops/oop.inline.hpp"
 #include "runtime/java.hpp"
+#include "runtime/orderAccess.hpp"
 #include "utilities/align.hpp"
 
 PSOldGen::PSOldGen(ReservedSpace rs, size_t initial_size, size_t min_size,
@@ -381,6 +382,7 @@ void PSOldGen::post_resize() {
                       &ParallelScavengeHeap::heap()->workers() : NULL;
 
   // ALWAYS do this last!!
+  OrderAccess::storestore();
   object_space()->initialize(new_memregion,
                              SpaceDecorator::DontClear,
                              SpaceDecorator::DontMangle,

--- a/src/hotspot/share/gc/parallel/psOldGen.cpp
+++ b/src/hotspot/share/gc/parallel/psOldGen.cpp
@@ -381,7 +381,8 @@ void PSOldGen::post_resize() {
   WorkGang* workers = Thread::current()->is_VM_thread() ?
                       &ParallelScavengeHeap::heap()->workers() : NULL;
 
-  // ALWAYS do this last!!
+  // Ensure the space bounds are updated and made visible to other
+  // threads after the other data structures have been resized.
   OrderAccess::storestore();
   object_space()->initialize(new_memregion,
                              SpaceDecorator::DontClear,


### PR DESCRIPTION
Please review this change to ParallelGC oldgen allocation, adding a missing
memory barrier.

The problem arises in the interaction between concurrent oldgen allocations,
where each would, if done serially (in either order), require expansion of
the generation.

An allocation of size N compares the mutable space's (end - top) with N to
determine if space is available.  If available, use top as the start of the
object of size N (adjusting top atomically) and assert the resulting memory
region is in the covered area.  If not, then expand.

Expansion updates the covered region, then updates the space (i.e. end).
There is currently no memory barrier between those operations.

As a result, we can have thread1 having done an expansion, updating the
covered region and the space end. Because there's no memory barrier there,
the space end may be updated before the covered region as far as some other
thread is concerned.

Meanwhile thread2's allocation reads the new end and goes ahead with the
allocation (which would not have fit with the old end value), then fails the
covered region check because it used the old covered range.  Although the
reads of end and the covered range are ordered here by the intervening CAS
of top, that doesn't help if the writes by thread1 are not also properly
ordered.

There is even a comment about this in PSOldGen::post_resize(), saying the
space update must be last (including after the covered region update).  But
without a memory barrier, there's nothing other than source order to ensure
that ordering.  So add a memory barrier.

I'm not sure whether this out-of-order update of the space end could lead to  
problems in a product build (where the assert doesn't apply).  Without
looking carefully, there appear to be opportunities for problems, such as
accessing uncovered parts of the card table.
 
There's another issue that I'm not addressing with this change.  Various
values are being read while subject to concurrent writes, without being in
any way tagged as atomic. (The writes are under the ExpandHeap_lock, the
reads are not.) This includes at least the covering region bounds and space
end.

Testing:
mach5 tier1
I was unable to reproduce the failure, so can't show any before / after
improvement.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257999](https://bugs.openjdk.java.net/browse/JDK-8257999): Parallel GC crash in gc/parallel/TestDynShrinkHeap.java: new region is not in covered_region


### Reviewers
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**) ⚠️ Review applies to 8a5b6ce5c278a79c512b5acc2b8daf74984dabf5
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to 8a5b6ce5c278a79c512b5acc2b8daf74984dabf5


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/35/head:pull/35`
`$ git checkout pull/35`
