### PR TITLE
8257636: Update usage of "type" terminology in java.lang.Class and java.lang.reflect

### DIFF
--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -91,8 +91,8 @@ import sun.reflect.misc.ReflectUtil;
 
 /**
  * Instances of the class {@code Class} represent classes and
- * interfaces in a running Java application. An enum type and a record
- * type are kinds of class; an annotation type is a kind of
+ * interfaces in a running Java application. An enum class and a record
+ * class are kinds of class; an annotation interface is a kind of
  * interface. Every array also belongs to a class that is reflected as
  * a {@code Class} object that is shared by all arrays with the same
  * element type and number of dimensions.  The primitive Java types
@@ -131,7 +131,7 @@ import sun.reflect.misc.ReflectUtil;
  * </pre></blockquote>
  *
  * It is also possible to get the {@code Class} object for a named
- * type (or for {@code void}) using a <i>class literal</i>.
+ * class or interface (or for {@code void}) using a <i>class literal</i>.
  * For example:
  *
  * <blockquote>
@@ -159,8 +159,8 @@ import sun.reflect.misc.ReflectUtil;
  * {@link java.lang.invoke.MethodHandles.Lookup#defineHiddenClass(byte[], boolean, MethodHandles.Lookup.ClassOption...)
  * Lookup::defineHiddenClass} is a {@linkplain Class#isHidden() <em>hidden</em>}
  * class or interface.
- * All kinds of class, including enum types and record types, may be
- * hidden classes; all kinds of interface, including annotation types,
+ * All kinds of class, including enum classes and record classes, may be
+ * hidden classes; all kinds of interface, including annotation interfaces,
  * may be hidden interfaces.
  *
  * The {@linkplain #getName() name of a hidden class or interface} is
@@ -294,7 +294,7 @@ public final class Class<T> implements java.io.Serializable,
                 if (isAnnotation()) {
                     sb.append('@');
                 }
-                if (isInterface()) { // Note: all annotation types are interfaces
+                if (isInterface()) { // Note: all annotation interfaces are interfaces
                     sb.append("interface");
                 } else {
                     if (isEnum())
@@ -767,11 +767,11 @@ public final class Class<T> implements java.io.Serializable,
 
     /**
      * Returns true if this {@code Class} object represents an annotation
-     * type.  Note that if this method returns true, {@link #isInterface()}
-     * would also return true, as all annotation types are also interfaces.
+     * interface.  Note that if this method returns true, {@link #isInterface()}
+     * would also return true, as all annotation interfaces are also interfaces.
      *
      * @return {@code true} if this {@code Class} object represents an annotation
-     *      type; {@code false} otherwise
+     *      interface; {@code false} otherwise
      * @since 1.5
      */
     public boolean isAnnotation() {
@@ -1298,7 +1298,7 @@ public final class Class<T> implements java.io.Serializable,
      * {@code null} otherwise.
      *
      * In particular, this method returns {@code null} if the underlying
-     * class is a local or anonymous class immediately enclosed by a type
+     * class is a local or anonymous class immediately enclosed by a class or interface
      * declaration, instance initializer or static initializer.
      *
      * @return the immediately enclosing method of the underlying class, if
@@ -1456,7 +1456,7 @@ public final class Class<T> implements java.io.Serializable,
      * the immediately enclosing constructor of the underlying
      * class. Returns {@code null} otherwise.  In particular, this
      * method returns {@code null} if the underlying class is a local
-     * or anonymous class immediately enclosed by a type declaration,
+     * or anonymous class immediately enclosed by a class or interface declaration,
      * instance initializer or static initializer.
      *
      * @return the immediately enclosing constructor of the underlying class, if
@@ -1650,9 +1650,9 @@ public final class Class<T> implements java.io.Serializable,
     }
 
     /**
-     * Return an informative string for the name of this type.
+     * Return an informative string for the name of this class or interface.
      *
-     * @return an informative string for the name of this type
+     * @return an informative string for the name of this class or interface
      * @since 1.8
      */
     public String getTypeName() {
@@ -2371,7 +2371,7 @@ public final class Class<T> implements java.io.Serializable,
      *
      *          </ul>
      *
-     * @jls 8.10 Record Types
+     * @jls 8.10 Record Classes
      * @since 16
      */
     @CallerSensitive
@@ -2392,12 +2392,12 @@ public final class Class<T> implements java.io.Serializable,
      * Class} object, including public, protected, default (package)
      * access, and private methods, but excluding inherited methods.
      *
-     * <p> If this {@code Class} object represents a type that has multiple
+     * <p> If this {@code Class} object represents a class or interface that has multiple
      * declared methods with the same name and parameter types, but different
      * return types, then the returned array has a {@code Method} object for
      * each such method.
      *
-     * <p> If this {@code Class} object represents a type that has a class
+     * <p> If this {@code Class} object represents a class or interface that has a class
      * initialization method {@code <clinit>}, then the returned array does
      * <em>not</em> have a corresponding {@code Method} object.
      *
@@ -3671,13 +3671,13 @@ public final class Class<T> implements java.io.Serializable,
      * Returns true if and only if this class was declared as an enum in the
      * source code.
      *
-     * Note that {@link java.lang.Enum} is not itself an enum type.
+     * Note that {@link java.lang.Enum} is not itself an enum class.
      *
      * Also note that if an enum constant is declared with a class body,
      * the class of that enum constant object is an anonymous class
-     * and <em>not</em> the class of the declaring enum type. The
+     * and <em>not</em> the class of the declaring enum class. The
      * {@link Enum#getDeclaringClass} method of an enum constant can
-     * be used to get the class of the enum type declaring the
+     * be used to get the class of the enum class declaring the
      * constant.
      *
      * @return true if and only if this class was declared as an enum in the
@@ -3702,11 +3702,11 @@ public final class Class<T> implements java.io.Serializable,
      * components; {@link #getRecordComponents()} returns a non-null but
      * possibly empty value for a record.
      *
-     * <p> Note that class {@link Record} is not a record type and thus invoking
+     * <p> Note that class {@link Record} is not a record class and thus invoking
      * this method on class {@code Record} returns {@code false}.
      *
      * @return true if and only if this class is a record class, otherwise false
-     * @jls 8.10 Record Types
+     * @jls 8.10 Record Classes
      * @since 16
      */
     public boolean isRecord() {
@@ -3730,12 +3730,12 @@ public final class Class<T> implements java.io.Serializable,
 
     /**
      * Returns the elements of this enum class or null if this
-     * Class object does not represent an enum type.
+     * Class object does not represent an enum class.
      *
      * @return an array containing the values comprising the enum class
      *     represented by this {@code Class} object in the order they're
      *     declared, or null if this {@code Class} object does not
-     *     represent an enum type
+     *     represent an enum class
      * @since 1.5
      */
     public T[] getEnumConstants() {
@@ -3745,7 +3745,7 @@ public final class Class<T> implements java.io.Serializable,
 
     /**
      * Returns the elements of this enum class or null if this
-     * Class object does not represent an enum type;
+     * Class object does not represent an enum class;
      * identical to getEnumConstants except that the result is
      * uncloned, cached, and shared by all callers.
      */
@@ -3788,7 +3788,7 @@ public final class Class<T> implements java.io.Serializable,
             T[] universe = getEnumConstantsShared();
             if (universe == null)
                 throw new IllegalArgumentException(
-                    getName() + " is not an enum type");
+                    getName() + " is not an enum class");
             directory = new HashMap<>((int)(universe.length / 0.75f) + 1);
             for (T constant : universe) {
                 directory.put(((Enum<?>)constant).name(), constant);
@@ -4024,7 +4024,7 @@ public final class Class<T> implements java.io.Serializable,
         return new AnnotationData(annotations, declaredAnnotations, classRedefinedCount);
     }
 
-    // Annotation types cache their internal (AnnotationType) form
+    // Annotation interfaces cache their internal (AnnotationType) form
 
     @SuppressWarnings("UnusedDeclaration")
     private transient volatile AnnotationType annotationType;
@@ -4050,10 +4050,10 @@ public final class Class<T> implements java.io.Serializable,
      * Returns an {@code AnnotatedType} object that represents the use of a
      * type to specify the superclass of the entity represented by this {@code
      * Class} object. (The <em>use</em> of type Foo to specify the superclass
-     * in '...  extends Foo' is distinct from the <em>declaration</em> of type
+     * in '...  extends Foo' is distinct from the <em>declaration</em> of class
      * Foo.)
      *
-     * <p> If this {@code Class} object represents a type whose declaration
+     * <p> If this {@code Class} object represents a class whose declaration
      * does not explicitly indicate an annotated superclass, then the return
      * value is an {@code AnnotatedType} object representing an element with no
      * annotations.
@@ -4082,7 +4082,7 @@ public final class Class<T> implements java.io.Serializable,
      * of types to specify superinterfaces of the entity represented by this
      * {@code Class} object. (The <em>use</em> of type Foo to specify a
      * superinterface in '... implements Foo' is distinct from the
-     * <em>declaration</em> of type Foo.)
+     * <em>declaration</em> of interface Foo.)
      *
      * <p> If this {@code Class} object represents a class, the return value is
      * an array containing objects representing the uses of interface types to

--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -1298,8 +1298,8 @@ public final class Class<T> implements java.io.Serializable,
      * {@code null} otherwise.
      *
      * In particular, this method returns {@code null} if the underlying
-     * class is a local or anonymous class immediately enclosed by a class or interface
-     * declaration, instance initializer or static initializer.
+     * class is a local or anonymous class immediately enclosed by a class or
+     * interface declaration, instance initializer or static initializer.
      *
      * @return the immediately enclosing method of the underlying class, if
      *     that class is a local or anonymous class; otherwise {@code null}.
@@ -1456,8 +1456,8 @@ public final class Class<T> implements java.io.Serializable,
      * the immediately enclosing constructor of the underlying
      * class. Returns {@code null} otherwise.  In particular, this
      * method returns {@code null} if the underlying class is a local
-     * or anonymous class immediately enclosed by a class or interface declaration,
-     * instance initializer or static initializer.
+     * or anonymous class immediately enclosed by a class or
+     * interface declaration, instance initializer or static initializer.
      *
      * @return the immediately enclosing constructor of the underlying class, if
      *     that class is a local or anonymous class; otherwise {@code null}.
@@ -2392,14 +2392,14 @@ public final class Class<T> implements java.io.Serializable,
      * Class} object, including public, protected, default (package)
      * access, and private methods, but excluding inherited methods.
      *
-     * <p> If this {@code Class} object represents a class or interface that has multiple
-     * declared methods with the same name and parameter types, but different
-     * return types, then the returned array has a {@code Method} object for
-     * each such method.
+     * <p> If this {@code Class} object represents a class or interface that
+     * has multiple declared methods with the same name and parameter types,
+     * but different return types, then the returned array has a {@code Method}
+     * object for each such method.
      *
-     * <p> If this {@code Class} object represents a class or interface that has a class
-     * initialization method {@code <clinit>}, then the returned array does
-     * <em>not</em> have a corresponding {@code Method} object.
+     * <p> If this {@code Class} object represents a class or interface that
+     * has a class initialization method {@code <clinit>}, then the returned
+     * array does <em>not</em> have a corresponding {@code Method} object.
      *
      * <p> If this {@code Class} object represents a class or interface with no
      * declared methods, then the returned array has length 0.
@@ -3702,8 +3702,8 @@ public final class Class<T> implements java.io.Serializable,
      * components; {@link #getRecordComponents()} returns a non-null but
      * possibly empty value for a record.
      *
-     * <p> Note that class {@link Record} is not a record class and thus invoking
-     * this method on class {@code Record} returns {@code false}.
+     * <p> Note that class {@link Record} is not a record class and thus
+     * invoking this method on class {@code Record} returns {@code false}.
      *
      * @return true if and only if this class is a record class, otherwise false
      * @jls 8.10 Record Classes

--- a/src/java.base/share/classes/java/lang/reflect/AnnotatedArrayType.java
+++ b/src/java.base/share/classes/java/lang/reflect/AnnotatedArrayType.java
@@ -46,7 +46,7 @@ public interface AnnotatedArrayType extends AnnotatedType {
 
     /**
      * Returns the potentially annotated type that this type is a member of, if
-     * this type represents a nested type. For example, if this type is
+     * this type represents a nested class or interface. For example, if this type is
      * {@code @TA O<T>.I<S>}, return a representation of {@code @TA O<T>}.
      *
      * <p>Returns {@code null} for an {@code AnnotatedType} that is an instance

--- a/src/java.base/share/classes/java/lang/reflect/AnnotatedArrayType.java
+++ b/src/java.base/share/classes/java/lang/reflect/AnnotatedArrayType.java
@@ -46,8 +46,8 @@ public interface AnnotatedArrayType extends AnnotatedType {
 
     /**
      * Returns the potentially annotated type that this type is a member of, if
-     * this type represents a nested class or interface. For example, if this type is
-     * {@code @TA O<T>.I<S>}, return a representation of {@code @TA O<T>}.
+     * this type represents a nested class or interface. For example, if this
+     * type is {@code @TA O<T>.I<S>}, return a representation of {@code @TA O<T>}.
      *
      * <p>Returns {@code null} for an {@code AnnotatedType} that is an instance
      *     of {@code AnnotatedArrayType}.

--- a/src/java.base/share/classes/java/lang/reflect/AnnotatedElement.java
+++ b/src/java.base/share/classes/java/lang/reflect/AnnotatedElement.java
@@ -248,7 +248,7 @@ import sun.reflect.annotation.AnnotationType;
  *
  * <p>Similarly, attempting to read an enum-valued member will result in
  * a {@link EnumConstantNotPresentException} if the enum constant in the
- * annotation is no longer present in the enum type.
+ * annotation is no longer present in the enum class.
  *
  * <p>If an annotation type <i>T</i> is (meta-)annotated with an
  * {@code @Repeatable} annotation whose value element indicates a type

--- a/src/java.base/share/classes/java/lang/reflect/AnnotatedParameterizedType.java
+++ b/src/java.base/share/classes/java/lang/reflect/AnnotatedParameterizedType.java
@@ -49,8 +49,8 @@ public interface AnnotatedParameterizedType extends AnnotatedType {
      * {@code @TA O<T>.I<S>}, return a representation of {@code @TA O<T>}.
      *
      * <p>Returns {@code null} if this {@code AnnotatedType} represents a
-     *     top-level class or interface, or a local or anonymous class, or a primitive type, or
-     *     void.
+     *     top-level class or interface, or a local or anonymous class, or
+     *     a primitive type, or void.
      *
      * @return an {@code AnnotatedType} object representing the potentially
      *     annotated type that this type is a member of, or {@code null}

--- a/src/java.base/share/classes/java/lang/reflect/AnnotatedParameterizedType.java
+++ b/src/java.base/share/classes/java/lang/reflect/AnnotatedParameterizedType.java
@@ -49,13 +49,13 @@ public interface AnnotatedParameterizedType extends AnnotatedType {
      * {@code @TA O<T>.I<S>}, return a representation of {@code @TA O<T>}.
      *
      * <p>Returns {@code null} if this {@code AnnotatedType} represents a
-     *     top-level type, or a local or anonymous class, or a primitive type, or
+     *     top-level class or interface, or a local or anonymous class, or a primitive type, or
      *     void.
      *
      * @return an {@code AnnotatedType} object representing the potentially
      *     annotated type that this type is a member of, or {@code null}
      * @throws TypeNotPresentException if the owner type
-     *     refers to a non-existent type declaration
+     *     refers to a non-existent class or interface declaration
      * @throws MalformedParameterizedTypeException if the owner type
      *     refers to a parameterized type that cannot be instantiated
      *     for any reason

--- a/src/java.base/share/classes/java/lang/reflect/AnnotatedType.java
+++ b/src/java.base/share/classes/java/lang/reflect/AnnotatedType.java
@@ -55,7 +55,7 @@ public interface AnnotatedType extends AnnotatedElement {
      * {@code @TA O<T>.I<S>}, return a representation of {@code @TA O<T>}.
      *
      * <p>Returns {@code null} if this {@code AnnotatedType} represents a
-     *     top-level type, or a local or anonymous class, or a primitive type, or
+     *     top-level class or interface, or a local or anonymous class, or a primitive type, or
      *     void.
      *
      * <p>Returns {@code null} if this {@code AnnotatedType} is an instance of
@@ -69,7 +69,7 @@ public interface AnnotatedType extends AnnotatedElement {
      * @return an {@code AnnotatedType} object representing the potentially
      *     annotated type that this type is a member of, or {@code null}
      * @throws TypeNotPresentException if the owner type
-     *     refers to a non-existent type declaration
+     *     refers to a non-existent class or interface declaration
      * @throws MalformedParameterizedTypeException if the owner type
      *     refers to a parameterized type that cannot be instantiated
      *     for any reason

--- a/src/java.base/share/classes/java/lang/reflect/AnnotatedType.java
+++ b/src/java.base/share/classes/java/lang/reflect/AnnotatedType.java
@@ -55,8 +55,8 @@ public interface AnnotatedType extends AnnotatedElement {
      * {@code @TA O<T>.I<S>}, return a representation of {@code @TA O<T>}.
      *
      * <p>Returns {@code null} if this {@code AnnotatedType} represents a
-     *     top-level class or interface, or a local or anonymous class, or a primitive type, or
-     *     void.
+     *     top-level class or interface, or a local or anonymous class, or
+     *     a primitive type, or void.
      *
      * <p>Returns {@code null} if this {@code AnnotatedType} is an instance of
      *     {@code AnnotatedArrayType}, {@code AnnotatedTypeVariable}, or

--- a/src/java.base/share/classes/java/lang/reflect/Constructor.java
+++ b/src/java.base/share/classes/java/lang/reflect/Constructor.java
@@ -462,7 +462,7 @@ public final class Constructor<T> extends Executable {
      *              after possible unwrapping, a parameter value
      *              cannot be converted to the corresponding formal
      *              parameter type by a method invocation conversion; if
-     *              this constructor pertains to an enum type.
+     *              this constructor pertains to an enum class.
      * @throws    InstantiationException    if the class that declares the
      *              underlying constructor represents an abstract class.
      * @throws    InvocationTargetException if the underlying constructor

--- a/src/java.base/share/classes/java/lang/reflect/Field.java
+++ b/src/java.base/share/classes/java/lang/reflect/Field.java
@@ -206,10 +206,10 @@ class Field extends AccessibleObject implements Member {
 
     /**
      * Returns {@code true} if this field represents an element of
-     * an enumerated type; returns {@code false} otherwise.
+     * an enumerated class; returns {@code false} otherwise.
      *
      * @return {@code true} if and only if this field represents an element of
-     * an enumerated type.
+     * an enumerated class.
      * @since 1.5
      */
     public boolean isEnumConstant() {
@@ -258,7 +258,7 @@ class Field extends AccessibleObject implements Member {
      *     <cite>The Java Virtual Machine Specification</cite>
      * @throws TypeNotPresentException if the generic type
      *     signature of the underlying field refers to a non-existent
-     *     type declaration
+     *     class or interface declaration
      * @throws MalformedParameterizedTypeException if the generic
      *     signature of the underlying field refers to a parameterized type
      *     that cannot be instantiated for any reason

--- a/src/java.base/share/classes/java/lang/reflect/GenericArrayType.java
+++ b/src/java.base/share/classes/java/lang/reflect/GenericArrayType.java
@@ -45,7 +45,7 @@ public interface GenericArrayType extends Type {
      * @return  a {@code Type} object representing the component type
      *     of this array
      * @throws TypeNotPresentException if the underlying array type's
-     *     component type refers to a non-existent type declaration
+     *     component type refers to a non-existent class or interface declaration
      * @throws MalformedParameterizedTypeException if  the
      *     underlying array type's component type refers to a
      *     parameterized type that cannot be instantiated for any reason

--- a/src/java.base/share/classes/java/lang/reflect/GenericArrayType.java
+++ b/src/java.base/share/classes/java/lang/reflect/GenericArrayType.java
@@ -44,8 +44,8 @@ public interface GenericArrayType extends Type {
      *
      * @return  a {@code Type} object representing the component type
      *     of this array
-     * @throws TypeNotPresentException if the underlying array type's
-     *     component type refers to a non-existent class or interface declaration
+     * @throws TypeNotPresentException if the underlying array type's component
+     *     type refers to a non-existent class or interface declaration
      * @throws MalformedParameterizedTypeException if  the
      *     underlying array type's component type refers to a
      *     parameterized type that cannot be instantiated for any reason

--- a/src/java.base/share/classes/java/lang/reflect/GenericSignatureFormatError.java
+++ b/src/java.base/share/classes/java/lang/reflect/GenericSignatureFormatError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,7 @@ package java.lang.reflect;
 /**
  * Thrown when a syntactically malformed signature attribute is
  * encountered by a reflective method that needs to interpret the
- * generic signature information for a type, method or constructor.
+ * generic signature information for a class or interface, method or constructor.
  *
  * @since 1.5
  */

--- a/src/java.base/share/classes/java/lang/reflect/GenericSignatureFormatError.java
+++ b/src/java.base/share/classes/java/lang/reflect/GenericSignatureFormatError.java
@@ -28,8 +28,8 @@ package java.lang.reflect;
 
 /**
  * Thrown when a syntactically malformed signature attribute is
- * encountered by a reflective method that needs to interpret the
- * generic signature information for a class or interface, method or constructor.
+ * encountered by a reflective method that needs to interpret the generic
+ * signature information for a class or interface, method or constructor.
  *
  * @since 1.5
  */

--- a/src/java.base/share/classes/java/lang/reflect/Method.java
+++ b/src/java.base/share/classes/java/lang/reflect/Method.java
@@ -282,9 +282,9 @@ public final class Method extends Executable {
      *     specified in
      *     <cite>The Java Virtual Machine Specification</cite>
      * @throws TypeNotPresentException if the underlying method's
-     *     return type refers to a non-existent type declaration
+     *     return type refers to a non-existent class or interface declaration
      * @throws MalformedParameterizedTypeException if the
-     *     underlying method's return typed refers to a parameterized
+     *     underlying method's return type refers to a parameterized
      *     type that cannot be instantiated for any reason
      * @since 1.5
      */
@@ -603,8 +603,7 @@ public final class Method extends Executable {
      * method; returns {@code false} otherwise.
      *
      * A default method is a public non-abstract instance method, that
-     * is, a non-static method with a body, declared in an interface
-     * type.
+     * is, a non-static method with a body, declared in an interface.
      *
      * @return true if and only if this method is a default
      * method as defined by the Java Language Specification.

--- a/src/java.base/share/classes/java/lang/reflect/ParameterizedType.java
+++ b/src/java.base/share/classes/java/lang/reflect/ParameterizedType.java
@@ -32,8 +32,8 @@ package java.lang.reflect;
  *
  * <p>A parameterized type is created the first time it is needed by a
  * reflective method, as specified in this package. When a
- * parameterized type p is created, the generic class or interface declaration that
- * p instantiates is resolved, and all type arguments of p are created
+ * parameterized type p is created, the generic class or interface declaration
+ * that p instantiates is resolved, and all type arguments of p are created
  * recursively. See {@link java.lang.reflect.TypeVariable
  * TypeVariable} for details on the creation process for type
  * variables. Repeated creation of a parameterized type has no effect.
@@ -56,8 +56,8 @@ public interface ParameterizedType extends Type {
      *
      * @return an array of {@code Type} objects representing the actual type
      *     arguments to this type
-     * @throws TypeNotPresentException if any of the
-     *     actual type arguments refers to a non-existent class or interface declaration
+     * @throws TypeNotPresentException if any of the actual type arguments
+     *     refers to a non-existent class or interface declaration
      * @throws MalformedParameterizedTypeException if any of the
      *     actual type parameters refer to a parameterized type that cannot
      *     be instantiated for any reason

--- a/src/java.base/share/classes/java/lang/reflect/ParameterizedType.java
+++ b/src/java.base/share/classes/java/lang/reflect/ParameterizedType.java
@@ -32,7 +32,7 @@ package java.lang.reflect;
  *
  * <p>A parameterized type is created the first time it is needed by a
  * reflective method, as specified in this package. When a
- * parameterized type p is created, the generic type declaration that
+ * parameterized type p is created, the generic class or interface declaration that
  * p instantiates is resolved, and all type arguments of p are created
  * recursively. See {@link java.lang.reflect.TypeVariable
  * TypeVariable} for details on the creation process for type
@@ -40,7 +40,7 @@ package java.lang.reflect;
  *
  * <p>Instances of classes that implement this interface must implement
  * an equals() method that equates any two instances that share the
- * same generic type declaration and have equal type parameters.
+ * same generic class or interface declaration and have equal type parameters.
  *
  * @jls 4.5 Parameterized Types
  * @since 1.5
@@ -57,7 +57,7 @@ public interface ParameterizedType extends Type {
      * @return an array of {@code Type} objects representing the actual type
      *     arguments to this type
      * @throws TypeNotPresentException if any of the
-     *     actual type arguments refers to a non-existent type declaration
+     *     actual type arguments refers to a non-existent class or interface declaration
      * @throws MalformedParameterizedTypeException if any of the
      *     actual type parameters refer to a parameterized type that cannot
      *     be instantiated for any reason
@@ -86,7 +86,7 @@ public interface ParameterizedType extends Type {
      *     this type is a member of. If this type is a top-level type,
      *     {@code null} is returned
      * @throws TypeNotPresentException if the owner type
-     *     refers to a non-existent type declaration
+     *     refers to a non-existent class or interface declaration
      * @throws MalformedParameterizedTypeException if the owner type
      *     refers to a parameterized type that cannot be instantiated
      *     for any reason

--- a/src/java.base/share/classes/java/lang/reflect/Proxy.java
+++ b/src/java.base/share/classes/java/lang/reflect/Proxy.java
@@ -240,10 +240,11 @@ import static java.lang.module.ModuleDescriptor.Modifier.SYNTHETIC;
  *
  * <p>
  * A dynamic module can read the modules of all of the superinterfaces of a proxy
- * class and the modules of the classes and interfaces referenced by all public method signatures
- * of a proxy class.  If a superinterface or a referenced class or interface, say {@code T},
- * is in a non-exported package, the {@linkplain Module module} of {@code T} is
- * updated to export the package of {@code T} to the dynamic module.
+ * class and the modules of the classes and interfaces referenced by
+ * all public method signatures of a proxy class.  If a superinterface or
+ * a referenced class or interface, say {@code T}, is in a non-exported package,
+ * the {@linkplain Module module} of {@code T} is updated to export the
+ * package of {@code T} to the dynamic module.
  *
  * <h3>Methods Duplicated in Multiple Proxy Interfaces</h3>
  *

--- a/src/java.base/share/classes/java/lang/reflect/Proxy.java
+++ b/src/java.base/share/classes/java/lang/reflect/Proxy.java
@@ -240,8 +240,8 @@ import static java.lang.module.ModuleDescriptor.Modifier.SYNTHETIC;
  *
  * <p>
  * A dynamic module can read the modules of all of the superinterfaces of a proxy
- * class and the modules of the types referenced by all public method signatures
- * of a proxy class.  If a superinterface or a referenced type, say {@code T},
+ * class and the modules of the classes and interfaces referenced by all public method signatures
+ * of a proxy class.  If a superinterface or a referenced class or interface, say {@code T},
  * is in a non-exported package, the {@linkplain Module module} of {@code T} is
  * updated to export the package of {@code T} to the dynamic module.
  *

--- a/src/java.base/share/classes/java/lang/reflect/ProxyGenerator.java
+++ b/src/java.base/share/classes/java/lang/reflect/ProxyGenerator.java
@@ -206,7 +206,8 @@ final class ProxyGenerator extends ClassWriter {
      * Return an array of the class and interface names from an array of Classes.
      *
      * @param classes an array of classes or interfaces
-     * @return the array of class and interface names; or null if classes is empty
+     * @return the array of class and interface names; or null if classes is
+     * null or empty
      */
     private static String[] typeNames(List<Class<?>> classes) {
         if (classes == null || classes.size() == 0)

--- a/src/java.base/share/classes/java/lang/reflect/ProxyGenerator.java
+++ b/src/java.base/share/classes/java/lang/reflect/ProxyGenerator.java
@@ -203,10 +203,10 @@ final class ProxyGenerator extends ClassWriter {
     }
 
     /**
-     * Return an array of the type names from an array of Classes.
+     * Return an array of the class and interface names from an array of Classes.
      *
      * @param classes an array of classes or interfaces
-     * @return the array of class names; or null if there are no classes
+     * @return the array of class and interface names; or null if classes is empty
      */
     private static String[] typeNames(List<Class<?>> classes) {
         if (classes == null || classes.size() == 0)

--- a/src/java.base/share/classes/java/lang/reflect/RecordComponent.java
+++ b/src/java.base/share/classes/java/lang/reflect/RecordComponent.java
@@ -43,7 +43,7 @@ import java.util.Objects;
  *
  * @see Class#getRecordComponents()
  * @see java.lang.Record
- * @jls 8.10 Record Types
+ * @jls 8.10 Record Classes
  * @since 16
  */
 public final class RecordComponent implements AnnotatedElement {
@@ -83,7 +83,7 @@ public final class RecordComponent implements AnnotatedElement {
     }
 
     /**
-     * Returns a {@code String} that describes the  generic type signature for
+     * Returns a {@code String} that describes the generic type signature for
      * this record component.
      *
      * @return a {@code String} that describes the generic type signature for


### PR DESCRIPTION
Another change to align with upcoming changes in the JLS terminology ('type' versus 'class and interface').

For background see: https://download.java.net/java/early_access/jdk16/docs/specs/class-terminology-jls.html

Where a class models types (as in the type of a variable or an expression), the change in terminology is mostly not applicable. For easier reviewing, paragraphs will only be reflowed before the PR is integrated.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257636](https://bugs.openjdk.java.net/browse/JDK-8257636): Update usage of "type" terminology in java.lang.Class and java.lang.reflect


### Reviewers
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**) ⚠️ Review applies to ef9aed7000f643a7686b09c39117d743f4699d6d


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/36/head:pull/36`
`$ git checkout pull/36`
