### PR TITLE
8258505: [TESTBUG] TestDivZeroWithSplitIf.java fails due to missing UnlockDiagnosticVMOptions

### DIFF
--- a/test/hotspot/jtreg/compiler/loopopts/TestDivZeroWithSplitIf.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestDivZeroWithSplitIf.java
@@ -28,7 +28,7 @@
  * @summary Verify that zero check is executed before division/modulo operation.
  * @requires vm.compiler2.enabled
  * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:CompileOnly=compiler/loopopts/TestDivZeroWithSplitIf::test
- *                   -XX:+StressGCM -XX:StressSeed=873732072 compiler.loopopts.TestDivZeroWithSplitIf
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM -XX:StressSeed=873732072 compiler.loopopts.TestDivZeroWithSplitIf
  */
 
 package compiler.loopopts;


### PR DESCRIPTION
Just adding the missing `-XX:+UnlockDiagnosticVMOptions` flag to the test.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258505](https://bugs.openjdk.java.net/browse/JDK-8258505): [TESTBUG] TestDivZeroWithSplitIf.java fails due to missing UnlockDiagnosticVMOptions


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/37/head:pull/37`
`$ git checkout pull/37`
