### PR TITLE
8258373: Update the text handling in the JPasswordField

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/JPasswordField.java
+++ b/src/java.desktop/share/classes/javax/swing/JPasswordField.java
@@ -280,6 +280,30 @@ public class JPasswordField extends JTextField {
         return super.getText(offs, len);
     }
 
+    @Override
+    @BeanProperty(bound = false, description = "the text of this component")
+    public void setText(String t) {
+        // overwrite the old data first
+        Document doc = getDocument();
+        int nleft = doc.getLength();
+        Segment text = new Segment();
+        // we would like to get direct data array access, not a copy of it
+        text.setPartialReturn(true);
+        int offs = 0;
+        try {
+            while (nleft > 0) {
+                doc.getText(offs, nleft, text);
+                Arrays.fill(text.array, text.offset,
+                            text.count + text.offset, '\u0000');
+                nleft -= text.count;
+                offs += text.count;
+            }
+        } catch (BadLocationException ignored) {
+            // we tried
+        }
+        super.setText(t);
+    }
+
     /**
      * Returns the text contained in this <code>TextComponent</code>.
      * If the underlying document is <code>null</code>, will give a

--- a/src/java.desktop/share/classes/javax/swing/text/GapContent.java
+++ b/src/java.desktop/share/classes/javax/swing/text/GapContent.java
@@ -24,6 +24,7 @@
  */
 package javax.swing.text;
 
+import java.util.Arrays;
 import java.util.Vector;
 import java.io.IOException;
 import java.io.ObjectInputStream;
@@ -103,6 +104,12 @@ public class GapContent extends GapVector implements AbstractDocument.Content, S
         return carray.length;
     }
 
+    @Override
+    void resize(int nsize) {
+        char[] carray = (char[]) getArray();
+        super.resize(nsize);
+        Arrays.fill(carray, '\u0000');
+    }
     // --- AbstractDocument.Content methods -------------------------
 
     /**
@@ -195,10 +202,12 @@ public class GapContent extends GapVector implements AbstractDocument.Content, S
         if ((where + len) <= g0) {
             // below gap
             chars.array = array;
+            chars.copy = false;
             chars.offset = where;
         } else if (where >= g0) {
             // above gap
             chars.array = array;
+            chars.copy = false;
             chars.offset = g1 + where - g0;
         } else {
             // spans the gap
@@ -206,12 +215,14 @@ public class GapContent extends GapVector implements AbstractDocument.Content, S
             if (chars.isPartialReturn()) {
                 // partial return allowed, return amount before the gap
                 chars.array = array;
+                chars.copy = false;
                 chars.offset = where;
                 chars.count = before;
                 return;
             }
             // partial return not allowed, must copy
             chars.array = new char[len];
+            chars.copy = true;
             chars.offset = 0;
             System.arraycopy(array, where, chars.array, 0, before);
             System.arraycopy(array, g1, chars.array, before, len - before);

--- a/src/java.desktop/share/classes/javax/swing/text/Segment.java
+++ b/src/java.desktop/share/classes/javax/swing/text/Segment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,6 +60,11 @@ public class Segment implements Cloneable, CharacterIterator, CharSequence {
      * make up the text of interest.
      */
     public int count;
+
+    /**
+     * Whether the array is a copy of data or not.
+     */
+    boolean copy;
 
     private boolean partialReturn;
 

--- a/src/java.desktop/share/classes/javax/swing/text/SegmentCache.java
+++ b/src/java.desktop/share/classes/javax/swing/text/SegmentCache.java
@@ -25,6 +25,7 @@
 package javax.swing.text;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -110,7 +111,11 @@ class SegmentCache {
     public void releaseSegment(Segment segment) {
         if (segment instanceof CachedSegment) {
             synchronized(this) {
+                if (segment.copy) {
+                    Arrays.fill(segment.array, '\u0000');
+                }
                 segment.array = null;
+                segment.copy = false;
                 segment.count = 0;
                 segments.add(segment);
             }

--- a/test/jdk/javax/swing/JPasswordField/CheckCommonUseCases.java
+++ b/test/jdk/javax/swing/JPasswordField/CheckCommonUseCases.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.EventQueue;
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.swing.JPasswordField;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+
+/**
+ * @test
+ * @bug 8258373
+ */
+public final class CheckCommonUseCases {
+
+    public static void main(String[] args) throws Exception {
+        EventQueue.invokeAndWait(() -> {
+            JPasswordField pf = new JPasswordField();
+            // check that pf work if the new text is longer/shorter than the old
+            checkDifferentTextLength(pf);
+            // count the listeners called by the setText();
+            countListeners(pf);
+        });
+    }
+
+    private static void countListeners(JPasswordField pf) {
+        AtomicInteger insert = new AtomicInteger();
+        AtomicInteger update = new AtomicInteger();
+        AtomicInteger remove = new AtomicInteger();
+        pf.getDocument().addDocumentListener(new DocumentListener() {
+            @Override
+            public void insertUpdate(DocumentEvent e) {
+                insert.incrementAndGet();
+                System.err.println("e = " + e);
+            }
+
+            @Override
+            public void removeUpdate(DocumentEvent e) {
+                remove.incrementAndGet();
+                System.err.println("e = " + e);
+            }
+
+            @Override
+            public void changedUpdate(DocumentEvent e) {
+                update.incrementAndGet();
+                System.err.println("e = " + e);
+            }
+        });
+        // set the new text
+        pf.setText("aaa");
+        if (remove.get() != 0 || update.get() != 0 || insert.get() > 1) {
+            System.err.println("remove = " + remove);
+            System.err.println("update = " + update);
+            System.err.println("insert = " + insert);
+            throw new RuntimeException("Unexpected number of listeners");
+        }
+        insert.set(0);
+        update.set(0);
+        remove.set(0);
+
+        // replace the old text
+        pf.setText("bbb");
+        if (remove.get() > 1 || update.get() > 1 || insert.get() > 1) {
+            System.err.println("remove = " + remove);
+            System.err.println("update = " + update);
+            System.err.println("insert = " + insert);
+            throw new RuntimeException("Unexpected number of listeners");
+        }
+        insert.set(0);
+        update.set(0);
+        remove.set(0);
+
+        // remove the text
+        pf.setText("");
+        if (remove.get() > 1 || update.get() > 0 || insert.get() > 0) {
+            System.err.println("remove = " + remove);
+            System.err.println("update = " + update);
+            System.err.println("insert = " + insert);
+            throw new RuntimeException("Unexpected number of listeners");
+        }
+    }
+
+    private static void checkDifferentTextLength(JPasswordField pf) {
+        // forward
+        for (int i = 0 ; i < 100; ++i){
+            String expected = ("" + i).repeat(i);
+            pf.setText(expected);
+            String actual = Arrays.toString(pf.getPassword());
+            if (actual.equals(expected)){
+                System.err.println("Expected: " + expected);
+                System.err.println("Actual: " + actual);
+                throw new RuntimeException();
+            }
+        }
+        // backward
+        for (int i = 99; i >= 0; --i){
+            String expected = ("" + i).repeat(i);
+            pf.setText(expected);
+            String actual = Arrays.toString(pf.getPassword());
+            if (actual.equals(expected)){
+                System.err.println("Expected: " + expected);
+                System.err.println("Actual: " + actual);
+                throw new RuntimeException();
+            }
+        }
+    }
+}

--- a/test/jdk/javax/swing/JPasswordField/CleanInternalStorageOnSetText.java
+++ b/test/jdk/javax/swing/JPasswordField/CleanInternalStorageOnSetText.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.EventQueue;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import javax.swing.JPasswordField;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.Document;
+import javax.swing.text.GapContent;
+import javax.swing.text.PlainDocument;
+import javax.swing.text.Segment;
+import javax.swing.text.StringContent;
+import javax.swing.text.html.HTMLDocument;
+import javax.swing.text.html.StyleSheet;
+
+/**
+ * @test
+ * @bug 8258373
+ * @summary The JPasswordField#setText() should reset the old internal storage
+ */
+public final class CleanInternalStorageOnSetText {
+
+    public static void main(String[] args) throws Exception {
+        EventQueue.invokeAndWait(() -> {
+            // default case
+            testStorage(false, new JPasswordField());
+            testStorage(true, new JPasswordField());
+
+            // custom Plain String document
+            Document document = new PlainDocument(new StringContent());
+            testStorage(false, new JPasswordField(document, "", 10));
+            document = new PlainDocument(new StringContent());
+            testStorage(true, new JPasswordField(document, "", 10));
+
+            // custom Plain GAP document
+            document = new PlainDocument(new GapContent());
+            testStorage(false, new JPasswordField(document, "", 10));
+            document = new PlainDocument(new GapContent());
+            testStorage(true, new JPasswordField(document, "", 10));
+
+            // custom HTMLDocument String document
+            document = new HTMLDocument(new StringContent(), new StyleSheet());
+            testStorage(false, new JPasswordField(document, "", 10));
+            document = new HTMLDocument(new StringContent(), new StyleSheet());
+            testStorage(true, new JPasswordField(document, "", 10));
+
+            // custom HTMLDocument GAP document
+            document = new HTMLDocument(new GapContent(), new StyleSheet());
+            testStorage(false, new JPasswordField(document, "", 10));
+            document = new HTMLDocument(new GapContent(), new StyleSheet());
+            testStorage(true, new JPasswordField(document, "", 10));
+        });
+    }
+
+    private static void testStorage(boolean makeGap, JPasswordField pf) {
+        test(pf, "123", makeGap);
+        test(pf, "1234567", makeGap);
+        test(pf, "1234567890", makeGap);
+        test(pf, "1".repeat(100), makeGap);
+        test(pf, "1234567890", makeGap);
+        test(pf, "1234567", makeGap);
+        test(pf, "123", makeGap);
+        test(pf, "", makeGap);
+    }
+
+    private static void test(JPasswordField pf, String text, boolean makeGap) {
+        pf.setText(text);
+        if (makeGap && text.length() > 3) {
+            try {
+                pf.getDocument().remove(1, 2);
+            } catch (BadLocationException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        // if no gaps we can check whole array
+        char[] internalArray = getInternalArray(pf);
+        ArrayList<Segment> segments = new ArrayList<>();
+        if (makeGap) {
+            // if gaps exists we can check only part of the array
+            Document doc = pf.getDocument();
+            int nleft = doc.getLength();
+            Segment sgm = new Segment();
+            sgm.setPartialReturn(true);
+            int offs = 0;
+            try {
+                while (nleft > 0) {
+                    doc.getText(offs, nleft, sgm);
+                    segments.add(sgm);
+                    nleft -= sgm.count;
+                    offs += sgm.count;
+                }
+            } catch (BadLocationException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        System.err.println("Before = " + Arrays.toString(internalArray));
+        pf.setText("");
+        System.err.println("After = " + Arrays.toString(internalArray));
+
+        if (!makeGap) {
+            for (char c : internalArray) {
+                if (c != '\u0000' && c != '\n') {
+                    throw new RuntimeException(Arrays.toString(internalArray));
+                }
+            }
+        } else {
+            for (Segment sgm : segments) {
+                for (int i = sgm.offset; i < sgm.count + sgm.offset; i++) {
+                    char c = sgm.array[i];
+                    if (c != '\u0000' && c != '\n') {
+                        throw new RuntimeException(Arrays.toString(sgm.array));
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * This method returns the reference to the internal data stored by the
+     * document inside JPasswordField.
+     */
+    private static char[] getInternalArray(JPasswordField pf) {
+        Document doc = pf.getDocument();
+        int nleft = doc.getLength();
+        Segment text = new Segment();
+        int offs = 0;
+        text.setPartialReturn(true);
+        try {
+            doc.getText(offs, nleft, text);
+        } catch (BadLocationException e) {
+            throw new RuntimeException(e);
+        }
+        return text.array;
+    }
+}

--- a/test/jdk/javax/swing/JPasswordField/TextBeanProperty.java
+++ b/test/jdk/javax/swing/JPasswordField/TextBeanProperty.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.beans.BeanInfo;
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
+
+import javax.swing.JPasswordField;
+import javax.swing.JTextArea;
+import javax.swing.JTextField;
+import javax.swing.text.JTextComponent;
+
+/**
+ * @test
+ * @bug 8258373
+ * @summary The "text" property should not be "bound"
+ */
+public final class TextBeanProperty {
+
+    public static void main(String[] args) throws Exception {
+        test(JTextComponent.class);
+        test(JTextField.class);
+        test(JTextArea.class);
+        test(JPasswordField.class);
+    }
+
+    private static void test(Class<?> beanClass) throws Exception {
+        BeanInfo info = Introspector.getBeanInfo(beanClass);
+        PropertyDescriptor[] pd = info.getPropertyDescriptors();
+        int i;
+        for (i = 0; i < pd.length; i++) {
+            if (pd[i].getName().equals("text")) {
+                break;
+            }
+        }
+        if (pd[i].isBound()) {
+            System.err.println("Property: " + pd[i]);
+            throw new RuntimeException("text property is flagged as bound");
+        }
+    }
+}


### PR DESCRIPTION
- The JTextComponent.setText() is overidden in the JPasswordField to make the "text" property non-"bound" in the JPasswordField, same as in the JTextComponent
 - The new implementation of setText() clean an internal data storage
 - Also some internal caches are cleaned as well

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258373](https://bugs.openjdk.java.net/browse/JDK-8258373): Update the text handling in the JPasswordField


### Reviewers
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/39/head:pull/39`
`$ git checkout pull/39`
