### PR TITLE
8258393: Shenandoah: "graph should be schedulable" assert failure

### DIFF
--- a/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.cpp
+++ b/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.cpp
@@ -2459,6 +2459,21 @@ bool MemoryGraphFixer::mem_is_valid(Node* m, Node* c) const {
 
 Node* MemoryGraphFixer::find_mem(Node* ctrl, Node* n) const {
   assert(n == NULL || _phase->ctrl_or_self(n) == ctrl, "");
+  assert(!ctrl->is_Call() || ctrl == n, "projection expected");
+#ifdef ASSERT
+  if ((ctrl->is_Proj() && ctrl->in(0)->is_Call()) ||
+          (ctrl->is_Catch() && ctrl->in(0)->in(0)->is_Call())){
+    CallNode* call = ctrl->is_Proj() ? ctrl->in(0)->as_Call() : ctrl->in(0)->in(0)->as_Call();
+    int mems = 0;
+    for (DUIterator_Fast imax, i = call->fast_outs(imax); i < imax; i++) {
+      Node* u = call->fast_out(i);
+      if (u->bottom_type() == Type::MEMORY) {
+        mems++;
+      }
+    }
+    assert(mems <= 1, "No node right after call if multiple mem projections");
+  }
+#endif
   Node* mem = _memory_nodes[ctrl->_idx];
   Node* c = ctrl;
   while (!mem_is_valid(mem, c) &&

--- a/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.cpp
+++ b/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.cpp
@@ -2462,7 +2462,7 @@ Node* MemoryGraphFixer::find_mem(Node* ctrl, Node* n) const {
   assert(!ctrl->is_Call() || ctrl == n, "projection expected");
 #ifdef ASSERT
   if ((ctrl->is_Proj() && ctrl->in(0)->is_Call()) ||
-          (ctrl->is_Catch() && ctrl->in(0)->in(0)->is_Call())){
+      (ctrl->is_Catch() && ctrl->in(0)->in(0)->is_Call())) {
     CallNode* call = ctrl->is_Proj() ? ctrl->in(0)->as_Call() : ctrl->in(0)->in(0)->as_Call();
     int mems = 0;
     for (DUIterator_Fast imax, i = call->fast_outs(imax); i < imax; i++) {

--- a/test/hotspot/jtreg/gc/shenandoah/compiler/TestBadRawMemoryAfterCall.java
+++ b/test/hotspot/jtreg/gc/shenandoah/compiler/TestBadRawMemoryAfterCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,8 +23,12 @@
 
 /**
  * @test
+ * @bug 8258393
+ * @summary Shenandoah: "graph should be schedulable" assert failure
+ * @requires vm.flavor == "server"
+ * @requires vm.gc.Shenandoah
  *
- * @run main/othervm -XX:+UseShenandoahGC TestBadRawMemoryAfterCall
+ * @run main/othervm -XX:+UseShenandoahGC -XX:-BackgroundCompilation TestBadRawMemoryAfterCall
  *
  */
 

--- a/test/hotspot/jtreg/gc/shenandoah/compiler/TestBadRawMemoryAfterCall.java
+++ b/test/hotspot/jtreg/gc/shenandoah/compiler/TestBadRawMemoryAfterCall.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2020, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ *
+ * @run main/othervm -XX:+UseShenandoahGC TestBadRawMemoryAfterCall
+ *
+ */
+
+public class TestBadRawMemoryAfterCall {
+    public static void main(String[] args) {
+        A a = new A();
+        B b = new B();
+        C c = new C();
+        for (int i = 0; i < 20_000; i++) {
+            test(a);
+            test(b);
+            test(c);
+        }
+    }
+
+    private static Object test(A a) {
+        if (a.getClass() == A.class) {
+        }
+
+        Object o = null;
+        try {
+            a.m();
+            o = a.getClass();
+        } catch (Exception e) {
+
+        }
+        return o;
+    }
+
+    private static class A {
+        void m() throws Exception {
+            throw new Exception();
+        }
+    }
+    private static class B extends A {
+        void m() {
+        }
+    }
+    private static class C extends B {
+        void m() {
+        }
+    }
+}


### PR DESCRIPTION
This is a shenandoah bug but the fix is in shared code.

At barrier expansion time, we need the raw memory state for the
control at which the barrier is expanded. Before expansion, the memory
graph is traversed and memory state for each control is recorded. In
that process, if opportunities to improve the memory graph are found,
the graph is modified. In the case of the failure, a raw memory load
was assigned a call projection as control but for that control, no
memory state was recorded and the fall back is to use the call's input
memory state. As a consequence the load's memory input is updated to a
wrong memory state. This causes the assert failure.

The call has 2 memory projections: one for the fallthrough and one for
the exception path. One projection is the memory state for the
CatchProj for the fallthrough, the other one for the CatchProj of the
exception path. For the control projection out of the call, there's no
memory state that makes sense and assigning the control projection of
the call as control for the load is the root cause of the
problem. This happens because anti-dependence analysis is too
conservative: a memory Phi that merges states from the exception and
fallthrough path is considered a dependency and that pushed the load
right after the call.

I propose to be less conservative in anti-dependence analysis for
Phis. For a Phi, when computing the LCA, I think it's sufficient to
only consider region's inputs that we actually reach by following the
memory edges and that's what I propose here.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258393](https://bugs.openjdk.java.net/browse/JDK-8258393): Shenandoah: "graph should be schedulable" assert failure


### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**) ⚠️ Review applies to 31f3bd1c9b01c3e9cf4a071eca7885dcefa01fbe
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/41/head:pull/41`
`$ git checkout pull/41`
