### PR TITLE
8257974: Regression 21% in DaCapo-lusearch-large after JDK-8236926

### DIFF
--- a/src/hotspot/share/gc/g1/g1UncommitRegionTask.cpp
+++ b/src/hotspot/share/gc/g1/g1UncommitRegionTask.cpp
@@ -59,7 +59,7 @@ void G1UncommitRegionTask::enqueue() {
 
   G1UncommitRegionTask* uncommit_task = instance();
   if (!uncommit_task->is_active()) {
-    // Change state to active and schedule with no delay.
+    // Change state to active and schedule using UncommitInitialDelayMs.
     uncommit_task->set_active(true);
     G1CollectedHeap::heap()->service_thread()->schedule_task(uncommit_task, UncommitInitialDelayMs);
   }

--- a/src/hotspot/share/gc/g1/g1UncommitRegionTask.cpp
+++ b/src/hotspot/share/gc/g1/g1UncommitRegionTask.cpp
@@ -61,7 +61,7 @@ void G1UncommitRegionTask::enqueue() {
   if (!uncommit_task->is_active()) {
     // Change state to active and schedule with no delay.
     uncommit_task->set_active(true);
-    G1CollectedHeap::heap()->service_thread()->schedule_task(uncommit_task, 0);
+    G1CollectedHeap::heap()->service_thread()->schedule_task(uncommit_task, UncommitInitialDelayMs);
   }
 }
 
@@ -124,9 +124,8 @@ void G1UncommitRegionTask::execute() {
   // Reschedule if there are more regions to uncommit, otherwise
   // change state to inactive.
   if (g1h->has_uncommittable_regions()) {
-    // No delay, reason to reschedule rather then to loop is to allow
-    // other tasks to run without waiting for a full uncommit cycle.
-    schedule(0);
+    // Delay to avoid starving application.
+    schedule(UncommitTaskDelayMs);
   } else {
     // Nothing more to do, change state and report a summary.
     set_active(false);

--- a/src/hotspot/share/gc/g1/g1UncommitRegionTask.hpp
+++ b/src/hotspot/share/gc/g1/g1UncommitRegionTask.hpp
@@ -30,10 +30,14 @@
 #include "utilities/ticks.hpp"
 
 class G1UncommitRegionTask : public G1ServiceTask {
-  // Each execution of the uncommit task is limited to uncommit at most 256M.
+  // Each execution of the uncommit task is limited to uncommit at most 128M.
   // This limit is small enough to ensure that the duration of each invocation
   // is short, while still making reasonable progress.
-  static const uint UncommitSizeLimit = 256 * M;
+  static const uint UncommitSizeLimit = 128 * M;
+  // Initial delay in milliseconds after GC before the regions are uncommitted.
+  static const uint UncommitInitialDelayMs = 100;
+  // The delay between two uncommit task executions.
+  static const uint UncommitTaskDelayMs = 10;
 
   static G1UncommitRegionTask* _instance;
   static void initialize();


### PR DESCRIPTION
Please review this fix to avoid the regression in DaCapo-lusearch-large.

**Summary** 
Doing uncommit concurrently with this benchmark was the cause of this regression. Using JFR we can see a lot of the java threads are blocking on a monitor when using the build with concurrent uncommit (but not otherwise). We know that the uncommit will affect the application threads and if a thread holding a lock gets stalled this will affect the overall performance more than expected. To avoid stalling the application threads more than necessary we can be a bit less aggressive when doing the uncommit. The initial version of concurrent uncommit tries to return the memory as quickly as possible after the GC, but there is no contract that we need to return the memory that quick and doing it a bit more lazy have more than one positive effect. 

The proposed change does three things: 
* first we delay the first uncommit after the GC shrinking the heap by 100ms, 
* after that each new invocation of the uncommit task will be delayed by 10ms (instead of run back to back)
* the size of each uncommit is changed from 256m to 128m, this will also lower the impact of each uncommit call. 

Doing these things will make the uncommit take a longer time and for applications where the uncommitted memory is needed quite quickly again, this will have the nice effect that instead of uncommitting/committing, we can just reuse the memory without involving the OS.

We have also done some experiments using `madvise` to do the uncommitting, but this doesn't fix the whole regression and needs some more investigation. A bit more information around this can be found in the bug report.

**Testing**
Tier1-3 in Mach5 and a lot of manual performance testing both locally and in our internal systems. Regression has been removed and in we instead see a small improvement, due to being able to reuse memory instead of uncommiting and then committing it again.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257974](https://bugs.openjdk.java.net/browse/JDK-8257974): Regression 21% in DaCapo-lusearch-large after JDK-8236926


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Author) ⚠️ Review applies to 2d5c88b466bcad900b4555e27da0396aac6bdbe3
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**) ⚠️ Review applies to 2d5c88b466bcad900b4555e27da0396aac6bdbe3
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to 2d5c88b466bcad900b4555e27da0396aac6bdbe3


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/42/head:pull/42`
`$ git checkout pull/42`
