### PR TITLE
8258515: javac should issue an error if an annotation is nested in a local class or interface

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symbol.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symbol.java
@@ -439,10 +439,10 @@ public abstract class Symbol extends AnnoConstruct implements PoolConstant, Elem
      *  Also includes fields of inner classes which are in
      *  turn local to a method or variable initializer.
      */
-    public boolean isLocal() {
+    public boolean isDirectlyOrIndirectlyLocal() {
         return
             (owner.kind.matches(KindSelector.VAL_MTH) ||
-             (owner.kind == TYP && owner.isLocal()));
+             (owner.kind == TYP && owner.isDirectlyOrIndirectlyLocal()));
     }
 
     /** Has this symbol an empty name? This includes anonymous
@@ -760,7 +760,7 @@ public abstract class Symbol extends AnnoConstruct implements PoolConstant, Elem
         public Symbol baseSymbol() { return other; }
         public Type erasure(Types types) { return other.erasure(types); }
         public Type externalType(Types types) { return other.externalType(types); }
-        public boolean isLocal() { return other.isLocal(); }
+        public boolean isDirectlyOrIndirectlyLocal() { return other.isDirectlyOrIndirectlyLocal(); }
         public boolean isConstructor() { return other.isConstructor(); }
         public Name getQualifiedName() { return other.getQualifiedName(); }
         public Name flatName() { return other.flatName(); }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -5165,7 +5165,7 @@ public class Attr extends JCTree.Visitor {
                     }
                 }
             } else {
-                if (c.isLocal() && !c.isEnum()) {
+                if (c.isDirectlyOrIndirectlyLocal() && !c.isEnum()) {
                     log.error(TreeInfo.diagnosticPositionFor(c, env.tree), Errors.LocalClassesCantExtendSealed(c.isAnonymous() ? Fragments.Anonymous : Fragments.Local));
                 }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -1216,7 +1216,8 @@ public class Check {
                 implicit |= sym.owner.flags_field & STRICTFP;
             break;
         case TYP:
-            if (sym.owner.kind.matches(KindSelector.VAL_MTH)) {
+            if (sym.owner.kind.matches(KindSelector.VAL_MTH) ||
+                    (sym.isDirectlyOrIndirectlyLocal() && (flags & ANNOTATION) != 0)) {
                 boolean implicitlyStatic = !sym.isAnonymous() &&
                         ((flags & RECORD) != 0 || (flags & ENUM) != 0 || (flags & INTERFACE) != 0);
                 boolean staticOrImplicitlyStatic = (flags & STATIC) != 0 || implicitlyStatic;
@@ -1225,7 +1226,7 @@ public class Check {
                 implicit = implicitlyStatic ? STATIC : implicit;
             } else if (sym.owner.kind == TYP) {
                 // statics in inner classes are allowed only if records are allowed too
-                mask = ((flags & STATIC) != 0) && allowRecords ? ExtendedMemberStaticClassFlags : ExtendedMemberClassFlags;
+                mask = ((flags & STATIC) != 0) && allowRecords && (flags & ANNOTATION) == 0 ? ExtendedMemberStaticClassFlags : ExtendedMemberClassFlags;
                 if (sym.owner.owner.kind == PCK ||
                     (sym.owner.flags_field & STATIC) != 0) {
                     mask |= STATIC;
@@ -2729,7 +2730,7 @@ public class Check {
 
             if (sym.kind == VAR) {
                 if ((sym.flags() & PARAMETER) != 0 ||
-                    sym.isLocal() ||
+                    sym.isDirectlyOrIndirectlyLocal() ||
                     sym.name == names._this ||
                     sym.name == names._super) {
                     return;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Enter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Enter.java
@@ -498,7 +498,7 @@ public class Enter extends JCTree.Visitor {
 
         // Add non-local class to uncompleted, to make sure it will be
         // completed later.
-        if (!c.isLocal() && uncompleted != null) uncompleted.append(c);
+        if (!c.isDirectlyOrIndirectlyLocal() && uncompleted != null) uncompleted.append(c);
 //      System.err.println("entering " + c.fullname + " in " + c.owner);//DEBUG
 
         // Recursively enter all member classes.

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
@@ -2904,7 +2904,7 @@ public class Flow {
         public void visitClassDef(JCClassDecl tree) {
             JCTree prevTree = currentTree;
             try {
-                currentTree = tree.sym.isLocal() ? tree : null;
+                currentTree = tree.sym.isDirectlyOrIndirectlyLocal() ? tree : null;
                 super.visitClassDef(tree);
             } finally {
                 currentTree = prevTree;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
@@ -1438,7 +1438,7 @@ public class LambdaToMethod extends TreeTranslator {
         public void visitNewClass(JCNewClass tree) {
             TypeSymbol def = tree.type.tsym;
             boolean inReferencedClass = currentlyInClass(def);
-            boolean isLocal = def.isLocal();
+            boolean isLocal = def.isDirectlyOrIndirectlyLocal();
             if ((inReferencedClass && isLocal || lambdaNewClassFilter(context(), tree))) {
                 TranslationContext<?> localContext = context();
                 final TypeSymbol outerInstanceSymbol = tree.type.getEnclosingType().tsym;
@@ -1592,7 +1592,7 @@ public class LambdaToMethod extends TreeTranslator {
             while (frameStack2.nonEmpty()) {
                 switch (frameStack2.head.tree.getTag()) {
                     case VARDEF:
-                        if (((JCVariableDecl)frameStack2.head.tree).sym.isLocal()) {
+                        if (((JCVariableDecl)frameStack2.head.tree).sym.isDirectlyOrIndirectlyLocal()) {
                             frameStack2 = frameStack2.tail;
                             break;
                         }
@@ -2313,7 +2313,7 @@ public class LambdaToMethod extends TreeTranslator {
                         !receiverAccessible() ||
                         (tree.getMode() == ReferenceMode.NEW &&
                           tree.kind != ReferenceKind.ARRAY_CTOR &&
-                          (tree.sym.owner.isLocal() || tree.sym.owner.isInner()));
+                          (tree.sym.owner.isDirectlyOrIndirectlyLocal() || tree.sym.owner.isInner()));
             }
 
             Type generatedRefSig() {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TypeEnter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TypeEnter.java
@@ -521,7 +521,7 @@ public class TypeEnter implements Completer {
             WriteableScope baseScope = WriteableScope.create(tree.sym);
             //import already entered local classes into base scope
             for (Symbol sym : env.outer.info.scope.getSymbols(NON_RECURSIVE)) {
-                if (sym.isLocal()) {
+                if (sym.isDirectlyOrIndirectlyLocal()) {
                     baseScope.enter(sym);
                 }
             }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/JNIWriter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/JNIWriter.java
@@ -143,7 +143,7 @@ public class JNIWriter {
 
     public boolean needsHeader(ClassSymbol c) {
         lazyInit();
-        if (c.isLocal() || isSynthetic(c))
+        if (c.isDirectlyOrIndirectlyLocal() || isSynthetic(c))
             return false;
         return (checkAll)
                 ? needsHeader(c.outermostClass(), true)
@@ -151,7 +151,7 @@ public class JNIWriter {
     }
 
     private boolean needsHeader(ClassSymbol c, boolean checkNestedClasses) {
-        if (c.isLocal() || isSynthetic(c))
+        if (c.isDirectlyOrIndirectlyLocal() || isSynthetic(c))
             return false;
 
         for (Symbol sym : c.members_field.getSymbols(NON_RECURSIVE)) {

--- a/test/langtools/tools/javac/records/RecordCompilationTests.java
+++ b/test/langtools/tools/javac/records/RecordCompilationTests.java
@@ -1027,6 +1027,110 @@ public class RecordCompilationTests extends CompilationTestCase {
                 """);
     }
 
+    public void testAnnoInsideLocalOrAnonymous() {
+        assertFail("compiler.err.annotation.decl.not.allowed.here",
+                """
+                class Outer {
+                    public void test() {
+                        class Local {
+                            @interface A {}
+                        }
+                    }
+                }
+                """);
+        assertFail("compiler.err.annotation.decl.not.allowed.here",
+                """
+                class Outer {
+                    public void test() {
+                        interface I {
+                            @interface A {}
+                        }
+                    }
+                }
+                """);
+        assertFail("compiler.err.annotation.decl.not.allowed.here",
+                """
+                class Outer {
+                    public void test() {
+                        record R() {
+                            @interface A {}
+                        }
+                    }
+                }
+                """);
+        assertFail("compiler.err.annotation.decl.not.allowed.here",
+                """
+                class Outer {
+                    public void test() {
+                        enum E {
+                            E1;
+                            @interface A {}
+                        }
+                    }
+                }
+                """);
+
+        assertFail("compiler.err.annotation.decl.not.allowed.here",
+                """
+                class Outer {
+                    public void test() {
+                        class Local1 {
+                            class Local2 {
+                                @interface A {}
+                            }
+                        }
+                    }
+                }
+                """);
+        assertFail("compiler.err.annotation.decl.not.allowed.here",
+                """
+                class Outer {
+                    public void test() {
+                        class Local {
+                            interface I {
+                                @interface A {}
+                            }
+                        }
+                    }
+                }
+                """);
+        assertFail("compiler.err.annotation.decl.not.allowed.here",
+                """
+                class Outer {
+                    public void test() {
+                        class Local {
+                            record R() {
+                                @interface A {}
+                            }
+                        }
+                    }
+                }
+                """);
+        assertFail("compiler.err.annotation.decl.not.allowed.here",
+                """
+                class Outer {
+                    public void test() {
+                        class Local {
+                            enum E {
+                                E1;
+                                @interface A {}
+                            }
+                        }
+                    }
+                }
+                """);
+
+        assertFail("compiler.err.annotation.decl.not.allowed.here",
+                """
+                class Outer {
+                    Runnable run = new Runnable() {
+                        @interface A {}
+                        public void run() {}
+                    };
+                }
+                """);
+    }
+
     public void testReceiverParameter() {
         assertFail("compiler.err.receiver.parameter.not.applicable.constructor.toplevel.class",
                 """


### PR DESCRIPTION
Spec [1](http://cr.openjdk.java.net/~gbierman/8246771/8246771-20200928/specs/local-statics-jls.html), section 9.6 Annotation Interfaces states that:

"It is a compile-time error if an annotation declaration is nested within the body of a local class or interface declaration (14.3), or within the body of an anonymous class"

javac is not implementing this assertion. The proposed patch is fixing this issue,

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258515](https://bugs.openjdk.java.net/browse/JDK-8258515): javac should issue an error if an annotation is nested in a local class or interface


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/43/head:pull/43`
`$ git checkout pull/43`
