### PR TITLE
8258647: TestCharVect2 is very slow

### DIFF
--- a/test/hotspot/jtreg/compiler/codegen/TestCharVect2.java
+++ b/test/hotspot/jtreg/compiler/codegen/TestCharVect2.java
@@ -26,18 +26,10 @@
  * @bug 8001183
  * @summary incorrect results of char vectors right shift operation
  *
- * @run main/othervm/timeout=400 -Xbatch -Xmx128m compiler.codegen.TestCharVect2
- */
-
-/**
- * @test
- * @bug 8001183
- * @summary incorrect results of char vectors right shift operation
- * @requires vm.compiler2.enabled | vm.graal.enabled
- *
- * @run main/othervm/timeout=400 -Xbatch -Xmx128m -XX:MaxVectorSize=8 compiler.codegen.TestCharVect2
- * @run main/othervm/timeout=400 -Xbatch -Xmx128m -XX:MaxVectorSize=16 compiler.codegen.TestCharVect2
- * @run main/othervm/timeout=400 -Xbatch -Xmx128m -XX:MaxVectorSize=32 compiler.codegen.TestCharVect2
+ * @run main/othervm -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m compiler.codegen.TestCharVect2
+ * @run main/othervm -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:MaxVectorSize=8 compiler.codegen.TestCharVect2
+ * @run main/othervm -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:MaxVectorSize=16 compiler.codegen.TestCharVect2
+ * @run main/othervm -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:MaxVectorSize=32 compiler.codegen.TestCharVect2
  */
 
 package compiler.codegen;


### PR DESCRIPTION
This is fixes compiler/codegen/TestCharVect2.java that suffers from the same problems as the tests fixed in JDK-8258225.

With the fix the test is fast enough to run with c1 only - so I removed the @requires attribute.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258647](https://bugs.openjdk.java.net/browse/JDK-8258647): TestCharVect2 is very slow


### Reviewers
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/46/head:pull/46`
`$ git checkout pull/46`
