### PR TITLE
8258687: Build broken on Windows after fix for JDK-8258134

### DIFF
--- a/src/hotspot/cpu/x86/gc/z/zBarrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/z/zBarrierSetAssembler_x86.cpp
@@ -374,7 +374,7 @@ OptoReg::Name ZBarrierSetAssembler::refine_register(const Node* node, OptoReg::N
 }
 
 // We use the vec_spill_helper from the x86.ad file to avoid reinventing this wheel
-extern int vec_spill_helper(CodeBuffer *cbuf, bool is_load,
+extern void vec_spill_helper(CodeBuffer *cbuf, bool is_load,
                             int stack_offset, int reg, uint ireg, outputStream* st);
 
 #undef __


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258687](https://bugs.openjdk.java.net/browse/JDK-8258687): Build broken on Windows after fix for JDK-8258134


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/51/head:pull/51`
`$ git checkout pull/51`
