### PR TITLE
8258007: Add instrumentation to NativeLibraryTest

### DIFF
--- a/test/jdk/java/lang/ClassLoader/nativeLibrary/NativeLibraryTest.java
+++ b/test/jdk/java/lang/ClassLoader/nativeLibrary/NativeLibraryTest.java
@@ -68,7 +68,7 @@ public class NativeLibraryTest {
             // unloadedCount is incremented when the native library is unloaded.
             while (count != unloadedCount) {
                 ForceGC gc = new ForceGC();
-                final int finalCount = count;            
+                final int finalCount = count;
                 if (!gc.await(() -> finalCount == unloadedCount)) {
                     System.err.print("Expected unloaded=" + count +
                         " but got=" + unloadedCount + ", try again...");

--- a/test/jdk/java/lang/ClassLoader/nativeLibrary/NativeLibraryTest.java
+++ b/test/jdk/java/lang/ClassLoader/nativeLibrary/NativeLibraryTest.java
@@ -66,13 +66,11 @@ public class NativeLibraryTest {
             // Unload the class loader and native library, and give the Cleaner
             // thread a chance to unload the native library.
             // unloadedCount is incremented when the native library is unloaded.
-            while (count != unloadedCount) {
-                ForceGC gc = new ForceGC();
-                final int finalCount = count;
-                if (!gc.await(() -> finalCount == unloadedCount)) {
-                    System.err.print("Expected unloaded=" + count +
-                        " but got=" + unloadedCount + ", try again...");
-                }
+            ForceGC gc = new ForceGC();
+            final int finalCount = count;
+            if (!gc.await(() -> finalCount == unloadedCount)) {
+                throw new RuntimeException("Expected unloaded=" + count +
+                    " but got=" + unloadedCount);
             }
         }
     }

--- a/test/jdk/java/lang/ClassLoader/nativeLibrary/NativeLibraryTest.java
+++ b/test/jdk/java/lang/ClassLoader/nativeLibrary/NativeLibraryTest.java
@@ -60,16 +60,19 @@ public class NativeLibraryTest {
         setup();
 
         for (int count=1; count <= 5; count++) {
+            System.out.println("count: " + count);
             // create a class loader and load a native library
             runTest();
             // Unload the class loader and native library, and give the Cleaner
             // thread a chance to unload the native library.
             // unloadedCount is incremented when the native library is unloaded.
-            ForceGC gc = new ForceGC();
-            final int finalCount = count;
-            if (!gc.await(() -> finalCount == unloadedCount)) {
-                throw new RuntimeException("Expected unloaded=" + count +
-                    " but got=" + unloadedCount);
+            while (count != unloadedCount) {
+                ForceGC gc = new ForceGC();
+                final int finalCount = count;            
+                if (!gc.await(() -> finalCount == unloadedCount)) {
+                    System.err.print("Expected unloaded=" + count +
+                        " but got=" + unloadedCount + ", try again...");
+                }
             }
         }
     }

--- a/test/lib/jdk/test/lib/util/ForceGC.java
+++ b/test/lib/jdk/test/lib/util/ForceGC.java
@@ -45,7 +45,7 @@ public class ForceGC {
         try {
             for (int i = 0; i < 10; i++) {
                 System.gc();
-                System.out.format("doit %d: gc %d%n", iter, i);
+                System.out.println("doit() iter: " + iter + ", gc " + i);
                 if (cleanerInvoked.await(1L, TimeUnit.SECONDS)) {
                     return;
                 }

--- a/test/lib/jdk/test/lib/util/ForceGC.java
+++ b/test/lib/jdk/test/lib/util/ForceGC.java
@@ -65,7 +65,8 @@ public class ForceGC {
      * @throws InterruptedException if the current thread is interrupted while waiting
      */
     public boolean await(BooleanSupplier s) {
-        o = null;
+        o = null; // Keep reference to Object until now, to ensure the Cleaner
+                  // doesn't count down the latch before await() is called.
         for (int i = 0; i < 10; i++) {
             if (s.getAsBoolean()) return true;
             doit(i);

--- a/test/lib/jdk/test/lib/util/ForceGC.java
+++ b/test/lib/jdk/test/lib/util/ForceGC.java
@@ -70,6 +70,9 @@ public class ForceGC {
         for (int i = 0; i < 10; i++) {
             if (s.getAsBoolean()) return true;
             doit(i);
+            try { Thread.sleep(1000); } catch (InterruptedException e) {
+                throw new AssertionError("unexpected interrupted sleep", e);
+            }
         }
         return false;
     }


### PR DESCRIPTION
This change adds some extra test output for NativeLibraryTest, primarily via an update to the ForceGC utility class.

It was observed that there was nothing preventing the Cleaner from cleaning the short-lived Object that ForceGC registers before await()/doit()/System.gc() is even called.

The new 'o' reference is kept alive until FoceGC.await() has been called.

We should find out a little more the next time NativeLibraryTest fails (or perhaps it won't fail anymore!)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258007](https://bugs.openjdk.java.net/browse/JDK-8258007): Add instrumentation to NativeLibraryTest


### Reviewers
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**) ⚠️ Review applies to 54a9e6d19cbd2239c9b5475aa2b23c9bba014b26
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**) ⚠️ Review applies to 9b5e57ca6e4c0ab52e72190c16e62c770a1adf43


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/53/head:pull/53`
`$ git checkout pull/53`
