### PR TITLE
8258714: Shenandoah: Process references before evacuation during degen

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -2055,6 +2055,15 @@ void ShenandoahHeap::op_weak_refs() {
   }
 }
 
+void ShenandoahHeap::stw_weak_refs(bool full_gc) {
+  // Weak refs processing
+  ShenandoahTimingsTracker t(full_gc ? ShenandoahPhaseTimings::full_gc_weakrefs_process
+                                     : ShenandoahPhaseTimings::degen_gc_weakrefs_process);
+  ShenandoahGCWorkerPhase worker_phase(full_gc ? ShenandoahPhaseTimings::full_gc_weakrefs_process
+                                               : ShenandoahPhaseTimings::degen_gc_weakrefs_process);
+  ref_processor()->process_references(workers(), false /* concurrent */);
+}
+
 void ShenandoahHeap::op_weak_roots() {
   if (is_concurrent_weak_root_in_progress()) {
     // Concurrent weak root processing
@@ -2192,12 +2201,6 @@ void ShenandoahHeap::op_degenerated(ShenandoahDegenPoint point) {
         // be disarmed while conc-roots phase is running.
         // TODO: Call op_conc_roots() here instead
         ShenandoahCodeRoots::disarm_nmethods();
-      }
-
-      {
-        ShenandoahTimingsTracker t(ShenandoahPhaseTimings::conc_weak_refs_work);
-        ShenandoahGCWorkerPhase worker_phase(ShenandoahPhaseTimings::conc_weak_refs_work);
-        ref_processor()->process_references(workers(), false /* concurrent */);
       }
 
       op_cleanup_early();
@@ -2485,6 +2488,7 @@ void ShenandoahHeap::stw_process_weak_roots(bool full_gc) {
 void ShenandoahHeap::parallel_cleaning(bool full_gc) {
   assert(SafepointSynchronize::is_at_safepoint(), "Must be at a safepoint");
   assert(is_stw_gc_in_progress(), "Only for Degenerated and Full GC");
+  stw_weak_refs(full_gc);
   stw_process_weak_roots(full_gc);
   stw_unload_classes(full_gc);
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -515,6 +515,7 @@ public:
 private:
   void stw_unload_classes(bool full_gc);
   void stw_process_weak_roots(bool full_gc);
+  void stw_weak_refs(bool full_gc);
 
   // Prepare concurrent root processing
   void prepare_concurrent_roots();

--- a/src/hotspot/share/gc/shenandoah/shenandoahMarkCompact.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMarkCompact.cpp
@@ -249,7 +249,6 @@ void ShenandoahMarkCompact::phase1_mark_heap() {
   cm->mark_roots(ShenandoahPhaseTimings::full_gc_scan_roots);
   cm->finish_mark_from_roots(/* full_gc = */ true);
   heap->mark_complete_marking_context();
-  rp->process_references(heap->workers(), false /* concurrent */);
   heap->parallel_cleaning(true /* full_gc */);
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.cpp
@@ -105,9 +105,11 @@ bool ShenandoahPhaseTimings::is_worker_phase(Phase phase) {
     case full_gc_adjust_roots:
     case degen_gc_scan_conc_roots:
     case degen_gc_update_roots:
+    case full_gc_weakrefs_process:
     case full_gc_scan_conc_roots:
     case full_gc_purge_class_unload:
     case full_gc_purge_weak_par:
+    case degen_gc_weakrefs_process:
     case degen_gc_purge_class_unload:
     case degen_gc_purge_weak_par:
     case heap_iteration_roots:

--- a/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
@@ -118,6 +118,8 @@ class outputStream;
   f(degen_gc,                                       "Pause Degenerated GC (N)")        \
   f(degen_gc_scan_conc_roots,                       "  Degen Mark Roots")              \
   SHENANDOAH_PAR_PHASE_DO(degen_gc_conc_mark_,      "    DM: ", f)                     \
+  f(degen_gc_weakrefs,                               "    Weak References")             \
+  f(degen_gc_weakrefs_process,                       "      Process")                   \
   f(degen_gc_purge,                                  "   System Purge")                \
   f(degen_gc_purge_class_unload,                     "     Unload Classes")            \
   SHENANDOAH_PAR_PHASE_DO(degen_gc_purge_cu_par_,    "       DCU: ", f)                \


### PR DESCRIPTION
Currently, when doing degen-cycle, we process references right before immediate-garbage cleanup. It is imperative that we process references before any immediate garbage gets recycled, or else we may end up with bad references during reference-processing. However, the trouble is that immediate garbage can be recycled even before cleanup phase by recycle-assist. For this reason, we must process references before any evacuation during degen GC. It is also more natural: we process refs before weak roots and class-unloading during concurrent cycle, and should do the same during degen cycle.
(Note that we already prevent recycle-assist in concurrent phase)

The change also adds STW timing for the weak-refs-processing, rather than polluting the conc-weak-refs timings.

Testing:
 - [x] 30 good runs of hotspot_gc_shenandoah, which showed the crash fairly reliably before

Ok?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258714](https://bugs.openjdk.java.net/browse/JDK-8258714): Shenandoah: Process references before evacuation during degen


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to fbeb6f773385e2dafeaba28f545dbeaf6b6a01a1


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/55/head:pull/55`
`$ git checkout pull/55`
