### PR TITLE
8258790: C2: Crash on empty macro node list

### DIFF
--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -2563,10 +2563,7 @@ void PhaseMacroExpand::eliminate_macro_nodes() {
   bool progress = true;
   while (progress) {
     progress = false;
-    for (int i = C->macro_count(); i > 0; i--) {
-      if (i > C->macro_count()) {
-        i = C->macro_count(); // more than 1 element can be eliminated at once
-      }
+    for (int i = C->macro_count(); i > 0; i = MIN2(i-1, C->macro_count())) { // more than 1 element can be eliminated at once
       Node* n = C->macro_node(i-1);
       bool success = false;
       DEBUG_ONLY(int old_macro_count = C->macro_count();)
@@ -2582,10 +2579,7 @@ void PhaseMacroExpand::eliminate_macro_nodes() {
   progress = true;
   while (progress) {
     progress = false;
-    for (int i = C->macro_count(); i > 0; i--) {
-      if (i > C->macro_count()) {
-        i = C->macro_count(); // more than 1 element can be eliminated at once
-      }
+    for (int i = C->macro_count(); i > 0; i = MIN2(i-1, C->macro_count())) { // more than 1 element can be eliminated at once
       Node* n = C->macro_node(i-1);
       bool success = false;
       DEBUG_ONLY(int old_macro_count = C->macro_count();)

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -2563,8 +2563,8 @@ void PhaseMacroExpand::eliminate_macro_nodes() {
   bool progress = true;
   while (progress) {
     progress = false;
-    for (int i = C->macro_count(); i > 0; i = MIN2(i-1, C->macro_count())) { // more than 1 element can be eliminated at once
-      Node* n = C->macro_node(i-1);
+    for (int i = C->macro_count(); i > 0; i = MIN2(i - 1, C->macro_count())) { // more than 1 element can be eliminated at once
+      Node* n = C->macro_node(i - 1);
       bool success = false;
       DEBUG_ONLY(int old_macro_count = C->macro_count();)
       if (n->is_AbstractLock()) {
@@ -2579,8 +2579,8 @@ void PhaseMacroExpand::eliminate_macro_nodes() {
   progress = true;
   while (progress) {
     progress = false;
-    for (int i = C->macro_count(); i > 0; i = MIN2(i-1, C->macro_count())) { // more than 1 element can be eliminated at once
-      Node* n = C->macro_node(i-1);
+    for (int i = C->macro_count(); i > 0; i = MIN2(i - 1, C->macro_count())) { // more than 1 element can be eliminated at once
+      Node* n = C->macro_node(i - 1);
       bool success = false;
       DEBUG_ONLY(int old_macro_count = C->macro_count();)
       switch (n->class_id()) {


### PR DESCRIPTION
The fix for 8257624 is incomplete: it doesn't cover the case when macro node array becomes empty as a result of multiple nodes removal. In such case, the out-of-bounds access still takes place (at index "-1"). 

Proposed fix is to adjust the index before performing "i > 0" check.    

Testing:
- [x] failing tests
- [ ] hs-precheckin-comp, hs-tier1, hs-tier2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258790](https://bugs.openjdk.java.net/browse/JDK-8258790): C2: Crash on empty macro node list


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to 174e98895687f123d2de6343c2091d8fd1a2a006
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/56/head:pull/56`
`$ git checkout pull/56`
