### PR TITLE
8258832: ProblemList com/sun/jdi/AfterThreadDeathTest.java on Linux-X64

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -809,6 +809,8 @@ com/sun/jdi/NashornPopFrameTest.java                            8225620 generic-
 
 com/sun/jdi/InvokeHangTest.java                                 8218463 linux-all
 
+com/sun/jdi/AfterThreadDeathTest.java                           8232839 linux-x64
+
 ############################################################################
 
 # jdk_time


### PR DESCRIPTION
This is a trivial fix to ProblemList com/sun/jdi/AfterThreadDeathTest.java on Linux-X64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258832](https://bugs.openjdk.java.net/browse/JDK-8258832): ProblemList com/sun/jdi/AfterThreadDeathTest.java on Linux-X64


### Reviewers
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**)
 * [Alex Menkov](https://openjdk.java.net/census#amenkov) (@alexmenkov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/59/head:pull/59`
`$ git checkout pull/59`
