### PR TITLE
8257521: runtime/logging/MonitorInflationTest.java crashed in MonitorList::unlink_deflated

### DIFF
--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -112,7 +112,8 @@ size_t MonitorList::unlink_deflated(Thread* self, LogStream* ls,
   ObjectMonitor* prev = NULL;
   ObjectMonitor* head = Atomic::load_acquire(&_head);
   ObjectMonitor* m = head;
-  do {
+  // The in-use list head can be NULL during the final audit.
+  while (m != NULL) {
     if (m->is_being_async_deflated()) {
       // Find next live ObjectMonitor.
       ObjectMonitor* next = m;
@@ -154,7 +155,7 @@ size_t MonitorList::unlink_deflated(Thread* self, LogStream* ls,
                                             "unlinked_count", unlinked_count,
                                             ls, timer_p);
     }
-  } while (m != NULL);
+  }
   Atomic::sub(&_count, unlinked_count);
   return unlinked_count;
 }


### PR DESCRIPTION
This is a trivial fix to MonitorList::unlink_deflated() to prevent it from
crashing when called with an empty in-use MonitorList. That condition
can only arise during the final audit during VM shutdown.

This fix has been tested with runtime/logging/MonitorInflationTest.java
combined with temporary debug code that delays the background threads
that normally call Object.wait() very early in the VM's life. By delaying those
background threads, we increase the likelihood of having an empty in-use
MonitorList.

The fix has also been tested with Mach5 Tier[1-3].

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257521](https://bugs.openjdk.java.net/browse/JDK-8257521): runtime/logging/MonitorInflationTest.java crashed in MonitorList::unlink_deflated


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/62/head:pull/62`
`$ git checkout pull/62`
