### PR TITLE
8258662: JDK 17ea: Crash compiling instanceof check involving sealed interface

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -1656,7 +1656,9 @@ public class Types {
         } else {
             result = isCastable.visit(t,s);
         }
-        if (result && (t.tsym.isSealed() || s.tsym.isSealed())) {
+        if (result && t.hasTag(CLASS) && t.tsym.kind.matches(Kinds.KindSelector.TYP)
+                && s.hasTag(CLASS) && s.tsym.kind.matches(Kinds.KindSelector.TYP)
+                && (t.tsym.isSealed() || s.tsym.isSealed())) {
             return (t.isCompound() || s.isCompound()) ?
                     false :
                     !areDisjoint((ClassSymbol)t.tsym, (ClassSymbol)s.tsym);

--- a/test/langtools/tools/javac/sealed/T8258662/T8258662.java
+++ b/test/langtools/tools/javac/sealed/T8258662/T8258662.java
@@ -4,9 +4,7 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/test/langtools/tools/javac/sealed/T8258662/T8258662.java
+++ b/test/langtools/tools/javac/sealed/T8258662/T8258662.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8258662
+ * @summary Types.isCastable crashes when involving sealed interface and type variable.
+ * @library /tools/lib
+ * @modules jdk.compiler/com.sun.tools.javac.api
+ *          jdk.compiler/com.sun.tools.javac.main
+ * @build toolbox.ToolBox toolbox.JavacTask
+ * @run main T8258662
+ */
+
+import java.util.List;
+
+import toolbox.ToolBox;
+import toolbox.TestRunner;
+import toolbox.JavacTask;
+
+public class T8258662 extends TestRunner {
+    private ToolBox tb;
+
+    public T8258662() {
+        super(System.err);
+        tb = new ToolBox();
+    }
+
+    public static void main(String[] args) throws Exception {
+        T8258662 t = new T8258662();
+        t.runTests();
+    }
+
+    @Test
+    public void testSealedClassIsCastable() throws Exception {
+        String code = """
+                class Test8258662 {
+                    sealed interface I<T> {
+                        final class C implements I<Object> { }
+                    }
+                    static <T extends I<Object>> void f(T x) {
+                        if (x instanceof I<Object>) { }
+                    }
+                }""";
+        new JavacTask(tb)
+                .sources(code)
+                .classpath(".")
+                .options("--enable-preview", "-source",  Integer.toString(Runtime.version().feature()))
+                .run()
+                .writeAll();
+    }
+
+}


### PR DESCRIPTION
Hi all,

The method `Types.isCastable` uses method `Types.areDisjoint` to do some check. But `Types.isCastable` doesn't check the type of the parameter before invoking method `Types.areDisjoint`. This patch adds the corresponding check and add a test case.

The original patch is in https://github.com/openjdk/jdk/pull/1849.

Thank you for taking the time to review.

Best Regards.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258662](https://bugs.openjdk.java.net/browse/JDK-8258662): JDK 17ea: Crash compiling instanceof check involving sealed interface


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**) ⚠️ Review applies to 4b07c7bc95a7620cd7c7c46acd6f2fac847d8d43


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/63/head:pull/63`
`$ git checkout pull/63`
