### PR TITLE
8258703: Incorrect 512-bit vector registers restore on x86_32

### DIFF
--- a/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
@@ -314,18 +314,19 @@ void RegisterSaver::restore_live_registers(MacroAssembler* masm, bool restore_ve
   }
 
   if (restore_vectors) {
+    off = additional_frame_bytes - ymm_bytes;
+    // Restore upper half of YMM registers.
+    for (int n = 0; n < num_xmm_regs; n++) {
+      __ vinsertf128_high(as_XMMRegister(n), Address(rsp, n*16+off));
+    }
+
     if (UseAVX > 2) {
       // Restore upper half of ZMM registers.
       for (int n = 0; n < num_xmm_regs; n++) {
         __ vinsertf64x4_high(as_XMMRegister(n), Address(rsp, n*32));
       }
-      __ addptr(rsp, zmm_bytes);
     }
-    // Restore upper half of YMM registers.
-    for (int n = 0; n < num_xmm_regs; n++) {
-      __ vinsertf128_high(as_XMMRegister(n), Address(rsp, n*16));
-    }
-    __ addptr(rsp, ymm_bytes);
+    __ addptr(rsp, additional_frame_bytes);
   }
 
   __ pop_FPU_state();


### PR DESCRIPTION
Hi all,

Following tests fail on our AVX512 machines with x86_32:
  - compiler/runtime/Test7196199.java
  - compiler/runtime/safepoints/TestRegisterRestoring.java
  - compiler/vectorization/TestVectorsNotSavedAtSafepoint.java

The reason is that 512-bit registers (zmm0 ~ zmm7) are restored incorrectly.

Current restore logic for 512-bit registers includes:
  1) restore zmm[511..256] [1]
  2) restore zmm[255..128] [2]  <-- Wrong on AVX512 with avx512vl

On our AVX512 machine, Assembler::vinsertf128 [3] was called in step 2).
According to the Intel instruction set reference,  vinsertf128 just copies the lower half of zmm, which lost the upper half of zmm.
```
   VINSERTF128 (VEX encoded version)
   TEMP[255:0] <- SRC1[255:0]
   CASE (imm8[0]) OF
   0: TEMP[127:0]   <- SRC2[127:0]
   1: TEMP[255:128] <- SRC2[127:0]
   ESAC
   DEST <- TEMP
```

The fix just changes the order of the restore logic for 512-bit registers:
  1) restore zmm[255..128] 
  2) restore zmm[511..256] 

Thanks.
Best regards,
Jie

[1] https://github.com/openjdk/jdk16/blob/master/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp#L320
[2] https://github.com/openjdk/jdk16/blob/master/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp#L326
[3] https://github.com/openjdk/jdk16/blob/master/src/hotspot/cpu/x86/macroAssembler_x86.hpp#L1463

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258703](https://bugs.openjdk.java.net/browse/JDK-8258703): Incorrect 512-bit vector registers restore on x86_32


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * sviswanathan - Committer ⚠️ Added manually

### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/64/head:pull/64`
`$ git checkout pull/64`
