### PR TITLE
8251377: [macos11] JTabbedPane selected tab text is barely legible

### DIFF
--- a/src/java.desktop/macosx/classes/apple/laf/JRSUIUtils.java
+++ b/src/java.desktop/macosx/classes/apple/laf/JRSUIUtils.java
@@ -37,6 +37,11 @@ public final class JRSUIUtils {
     static boolean isLeopard = isMacOSXLeopard();
     static boolean isSnowLeopardOrBelow = isMacOSXSnowLeopardOrBelow();
     static boolean isCatalinaOrAbove = isMacOSXCatalinaOrAbove();
+    static boolean isBigSurOrAbove = isMacOSXBigSurOrAbove();
+
+    public static boolean isMacOSXBigSurOrAbove() {
+        return currentMacOSXVersionMatchesGivenVersionRange(16, true, false, true);
+    }
 
     static boolean isMacOSXCatalinaOrAbove() {
         return currentMacOSXVersionMatchesGivenVersionRange(15, true, false, true);

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaImageFactory.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaImageFactory.java
@@ -496,4 +496,8 @@ public class AquaImageFactory {
     public static Color getSelectionInactiveForegroundColorUIResource() {
         return new SystemColorProxy(LWCToolkit.getAppleColor(LWCToolkit.INACTIVE_SELECTION_FOREGROUND_COLOR));
     }
+
+    public static Color getSelectedControlColorUIResource() {
+        return new SystemColorProxy(LWCToolkit.getAppleColor(LWCToolkit.SELECTED_CONTROL_TEXT_COLOR));
+    }
 }

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaLookAndFeel.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaLookAndFeel.java
@@ -870,7 +870,7 @@ public class AquaLookAndFeel extends BasicLookAndFeel {
             "TabbedPane.tabsOverlapBorder", Boolean.TRUE,
             "TabbedPane.selectedTabTitlePressedColor", selectedTabTitlePressedColor,
             "TabbedPane.selectedTabTitleDisabledColor", selectedTabTitleDisabledColor,
-            "TabbedPane.selectedTabTitleNormalColor", System.getProperty("os.version").contains("10.16") ? selectedControlTextColor : selectedTabTitleNormalColor,
+            "TabbedPane.selectedTabTitleNormalColor", JRSUIUtils.isMacOSXBigSurOrAbove() ? selectedControlTextColor : selectedTabTitleNormalColor,
             "TabbedPane.selectedTabTitleShadowDisabledColor", selectedTabTitleShadowDisabledColor,
             "TabbedPane.selectedTabTitleShadowNormalColor", selectedTabTitleShadowNormalColor,
             "TabbedPane.nonSelectedTabTitleNormalColor", nonSelectedTabTitleNormalColor,

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaLookAndFeel.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaLookAndFeel.java
@@ -328,6 +328,7 @@ public class AquaLookAndFeel extends BasicLookAndFeel {
         final ColorUIResource selectedTabTitlePressedColor = new ColorUIResource(240, 240, 240);
         final ColorUIResource selectedTabTitleDisabledColor = new ColorUIResource(new Color(1, 1, 1, 0.55f));
         final ColorUIResource selectedTabTitleNormalColor = white;
+        final Color selectedControlTextColor = AquaImageFactory.getSelectedControlColorUIResource();
         final ColorUIResource selectedTabTitleShadowDisabledColor = new ColorUIResource(new Color(0, 0, 0, 0.25f));
         final ColorUIResource selectedTabTitleShadowNormalColor = mediumTranslucentBlack;
         final ColorUIResource nonSelectedTabTitleNormalColor = black;
@@ -869,7 +870,7 @@ public class AquaLookAndFeel extends BasicLookAndFeel {
             "TabbedPane.tabsOverlapBorder", Boolean.TRUE,
             "TabbedPane.selectedTabTitlePressedColor", selectedTabTitlePressedColor,
             "TabbedPane.selectedTabTitleDisabledColor", selectedTabTitleDisabledColor,
-            "TabbedPane.selectedTabTitleNormalColor", selectedTabTitleNormalColor,
+            "TabbedPane.selectedTabTitleNormalColor", System.getProperty("os.version").contains("10.16") ? selectedControlTextColor : selectedTabTitleNormalColor,
             "TabbedPane.selectedTabTitleShadowDisabledColor", selectedTabTitleShadowDisabledColor,
             "TabbedPane.selectedTabTitleShadowNormalColor", selectedTabTitleShadowNormalColor,
             "TabbedPane.nonSelectedTabTitleNormalColor", nonSelectedTabTitleNormalColor,

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/LWCToolkit.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/LWCToolkit.java
@@ -204,14 +204,16 @@ public final class LWCToolkit extends LWToolkit {
     /*
      * System colors with default initial values, overwritten by toolkit if system values differ and are available.
      */
-    private static final int NUM_APPLE_COLORS = 3;
+    private static final int NUM_APPLE_COLORS = 4;
     public static final int KEYBOARD_FOCUS_COLOR = 0;
     public static final int INACTIVE_SELECTION_BACKGROUND_COLOR = 1;
     public static final int INACTIVE_SELECTION_FOREGROUND_COLOR = 2;
+    public static final int SELECTED_CONTROL_TEXT_COLOR = 3;
     private static int[] appleColors = {
         0xFF808080, // keyboardFocusColor = Color.gray;
         0xFFC0C0C0, // secondarySelectedControlColor
         0xFF303030, // controlDarkShadowColor
+        0xFFFFFFFF, // controlTextColor
     };
 
     private native void loadNativeColors(final int[] systemColors, final int[] appleColors);

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CSystemColors.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CSystemColors.m
@@ -117,6 +117,7 @@ static JNF_STATIC_MEMBER_CACHE(jm_systemColorsChanged, jc_LWCToolkit, "systemCol
     appleColors[sun_lwawt_macosx_LWCToolkit_KEYBOARD_FOCUS_COLOR] =                    [NSColor keyboardFocusIndicatorColor];
     appleColors[sun_lwawt_macosx_LWCToolkit_INACTIVE_SELECTION_BACKGROUND_COLOR] =    [NSColor secondarySelectedControlColor];
     appleColors[sun_lwawt_macosx_LWCToolkit_INACTIVE_SELECTION_FOREGROUND_COLOR] =    [NSColor controlDarkShadowColor];
+    appleColors[sun_lwawt_macosx_LWCToolkit_SELECTED_CONTROL_TEXT_COLOR] =            [NSColor controlTextColor];
 
     for (i = 0; i < sun_lwawt_macosx_LWCToolkit_NUM_APPLE_COLORS; i++) {
         [appleColors[i] retain];


### PR DESCRIPTION
Please review a fix for jdk16.
On macOS 11 (bigsur), using the Swing Aqua Look and Feel, the text of the selected JTabbedPane tab title text is just a light gray outline of white text on a white background. The macOS 11 design inverted from dark background / light text to light background / dark text, so white text on white background is not legible.
Correct system color to use for this scenario, as per Apple, is [NSColor controlTextColor]
so the proposed fix is to use this system color for BigSur. 
For preBigSur releases, "white" is still used as the above color is for text color but the tabPane background color is still not readable through any Apple API, so [NSColor controlTextColor] which returns black will not be legible on preBigSur releases which has black background.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8251377](https://bugs.openjdk.java.net/browse/JDK-8251377): [macos11] JTabbedPane selected tab text is barely legible


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/65/head:pull/65`
`$ git checkout pull/65`
