### PR TITLE
JDK-8258916: javac/doclint reports broken HTML on multiline mailto links

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/DocCommentParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/DocCommentParser.java
@@ -917,6 +917,7 @@ public class DocCommentParser {
                 nextChar();
                 skipWhitespace();
                 if (ch == '\'' || ch == '"') {
+                    newline = false;
                     vkind = (ch == '\'') ? ValueKind.SINGLE : ValueKind.DOUBLE;
                     char quote = ch;
                     nextChar();

--- a/test/langtools/tools/doclint/HtmlAttrsTest.java
+++ b/test/langtools/tools/doclint/HtmlAttrsTest.java
@@ -1,6 +1,6 @@
 /*
  * @test /nodynamiccopyright/
- * @bug 8004832
+ * @bug 8004832 8258916
  * @summary Add new doclint package
  * @modules jdk.javadoc/jdk.javadoc.internal.doclint
  * @build DocLintTester
@@ -24,5 +24,11 @@ public class HtmlAttrsTest {
      * <font size="3"> text </font>
      */
     public void obsolete_use_css() { }
+
+    /**
+     * multi-line mailto <a
+     * href="mailto:nobody@example.com">nobody</a>
+     */
+    public void multiline_mailto() { }
 }
 


### PR DESCRIPTION
Please review a trivial fix to correctly handle '@' inside the value of an HTML attribute. 
The fix is simply to cancel the `newline` flag that is set when a newline has been read.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258916](https://bugs.openjdk.java.net/browse/JDK-8258916): javac/doclint reports broken HTML on multiline mailto links


### Reviewers
 * [Jim Laskey](https://openjdk.java.net/census#jlaskey) (@JimLaskey - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/68/head:pull/68`
`$ git checkout pull/68`
