### PR TITLE
8258972: unexpected compilation error with generic sealed interface

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -1667,7 +1667,7 @@ public class Types {
     }
     // where
         private boolean areDisjoint(ClassSymbol ts, ClassSymbol ss) {
-            if (isSubtype(ts.type, ss.type)) {
+            if (isSubtype(erasure(ts.type), erasure(ss.type))) {
                 return false;
             }
             // if both are classes or both are interfaces, shortcut

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -1671,7 +1671,7 @@ public class Types {
                 return false;
             }
             // if both are classes or both are interfaces, shortcut
-            if (ts.isInterface() == ss.isInterface() && isSubtype(ss.type, ts.type)) {
+            if (ts.isInterface() == ss.isInterface() && isSubtype(erasure(ss.type), erasure(ts.type))) {
                 return false;
             }
             if (ts.isInterface() && !ss.isInterface()) {

--- a/test/langtools/tools/javac/sealed/SealedCompilationTests.java
+++ b/test/langtools/tools/javac/sealed/SealedCompilationTests.java
@@ -1247,6 +1247,17 @@ public class SealedCompilationTests extends CompilationTestCase {
                      a = (A)c;
                   }
                 }
+                """,
+                """
+                sealed interface A<T> {
+                    final class B implements A<Object> { }
+                }
+
+                class Test {
+                    void f(A.B a, A<Object> b) {
+                        a = (A.B)b;
+                    }
+                }
                 """
         )) {
             assertOK(s);


### PR DESCRIPTION
Hi,

Please review this fix to the implementation of section `5.1.6.1 Allowed Narrowing Reference Conversion` of the Sealed Classes spec [1](http://cr.openjdk.java.net/~gbierman/jep397/jep397-20201204/specs/sealed-classes-jls.html#jls-5.1.6.1). IMO the compiler was not implementing the spec to the letter in particular the inheritance relation between a sealed class and a subclass should be tested ignoring type arguments which is what this patch is doing. Comments?

Thanks,
Vicente

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258972](https://bugs.openjdk.java.net/browse/JDK-8258972): unexpected compilation error with generic sealed interface


### Reviewers
 * [Jan Lahoda](https://openjdk.java.net/census#jlahoda) (@lahodaj - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/72/head:pull/72`
`$ git checkout pull/72`
