### PR TITLE
8258955: (bf) slice(int, int) on view buffers fails to adjust index according to primitive size

### DIFF
--- a/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -237,7 +237,8 @@ class Direct$Type$Buffer$RW$$BO$
                                               0,
                                               length,
                                               length,
-                                              index, segment);
+                                              index << $LG_BYTES_PER_VALUE$,
+                                              segment);
     }
 
     public $Type$Buffer duplicate() {

--- a/test/jdk/java/nio/Buffer/ByteBufferViews.java
+++ b/test/jdk/java/nio/Buffer/ByteBufferViews.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /* @test
  * @summary Binary data and view tests for byte buffers
- * @bug 8159257
+ * @bug 8159257 8258955
  * @run testng ByteBufferViews
  */
 
@@ -174,6 +174,11 @@ public class ByteBufferViews {
                           bb -> bb.asShortBuffer()),
                 Map.entry("bb.asShortBuffer().slice()",
                           bb -> bb.asShortBuffer().slice()),
+                Map.entry("bb.asShortBuffer().slice(index,length)",
+                          bb -> { var sb = bb.asShortBuffer();
+                                  sb =  sb.slice(1, sb.limit() - 1);
+                                  bb.position(bb.position() + 2);
+                                  return sb; }),
                 Map.entry("bb.asShortBuffer().slice().duplicate()",
                           bb -> bb.asShortBuffer().slice().duplicate())
         );
@@ -273,6 +278,11 @@ public class ByteBufferViews {
                           bb -> bb.asCharBuffer()),
                 Map.entry("bb.asCharBuffer().slice()",
                           bb -> bb.asCharBuffer().slice()),
+                Map.entry("bb.asCharBuffer().slice(index,length)",
+                          bb -> { var cb = bb.asCharBuffer();
+                                  cb =  cb.slice(1, cb.limit() - 1);
+                                  bb.position(bb.position() + 2);
+                                  return cb; }),
                 Map.entry("bb.asCharBuffer().slice().duplicate()",
                           bb -> bb.asCharBuffer().slice().duplicate())
         );
@@ -365,6 +375,11 @@ public class ByteBufferViews {
                           bb -> bb.asIntBuffer()),
                 Map.entry("bb.asIntBuffer().slice()",
                           bb -> bb.asIntBuffer().slice()),
+                Map.entry("bb.asIntBuffer().slice(index,length)",
+                          bb -> { var ib = bb.asIntBuffer();
+                                  ib =  ib.slice(1, ib.limit() - 1);
+                                  bb.position(bb.position() + 4);
+                                  return ib; }),
                 Map.entry("bb.asIntBuffer().slice().duplicate()",
                           bb -> bb.asIntBuffer().slice().duplicate())
         );
@@ -467,6 +482,11 @@ public class ByteBufferViews {
                           bb -> bb.asLongBuffer()),
                 Map.entry("bb.asLongBuffer().slice()",
                           bb -> bb.asLongBuffer().slice()),
+                Map.entry("bb.asLongBuffer().slice(index,length)",
+                          bb -> { var lb = bb.asLongBuffer();
+                                  lb =  lb.slice(1, lb.limit() - 1);
+                                  bb.position(bb.position() + 8);
+                                  return lb; }),
                 Map.entry("bb.asLongBuffer().slice().duplicate()",
                           bb -> bb.asLongBuffer().slice().duplicate())
         );
@@ -575,6 +595,11 @@ public class ByteBufferViews {
                           bb -> bb.asFloatBuffer()),
                 Map.entry("bb.asFloatBuffer().slice()",
                           bb -> bb.asFloatBuffer().slice()),
+                Map.entry("bb.asFloatBuffer().slice(index,length)",
+                        bb -> { var fb = bb.asFloatBuffer();
+                            fb =  fb.slice(1, fb.limit() - 1);
+                            bb.position(bb.position() + 4);
+                            return fb; }),
                 Map.entry("bb.asFloatBuffer().slice().duplicate()",
                           bb -> bb.asFloatBuffer().slice().duplicate())
         );
@@ -668,6 +693,11 @@ public class ByteBufferViews {
                           bb -> bb.asDoubleBuffer()),
                 Map.entry("bb.asDoubleBuffer().slice()",
                           bb -> bb.asDoubleBuffer().slice()),
+                Map.entry("bb.asDoubleBuffer().slice(index,length)",
+                        bb -> { var db = bb.asDoubleBuffer();
+                            db =  db.slice(1, db.limit() - 1);
+                            bb.position(bb.position() + 8);
+                            return db; }),
                 Map.entry("bb.asDoubleBuffer().slice().duplicate()",
                           bb -> bb.asDoubleBuffer().slice().duplicate())
         );


### PR DESCRIPTION
Scale the slice start index per carrier width, for views of direct byte buffers. This never worked correctly since being added in Java 13.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258955](https://bugs.openjdk.java.net/browse/JDK-8258955): (bf) slice(int, int) on view buffers fails to adjust index according to primitive size


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/73/head:pull/73`
`$ git checkout pull/73`
