### PR TITLE
8259043: More Zero architectures need linkage with libatomic

### DIFF
--- a/make/autoconf/libraries.m4
+++ b/make/autoconf/libraries.m4
@@ -124,12 +124,18 @@ AC_DEFUN_ONCE([LIB_SETUP_LIBRARIES],
     BASIC_JVM_LIBS="$BASIC_JVM_LIBS -lpthread"
   fi
 
-  # Libatomic library
-  # 32-bit MIPS needs fallback library for 8-byte atomic ops
-  if test "x$OPENJDK_TARGET_OS" = xlinux &&
-      (test "x$OPENJDK_TARGET_CPU" = xmips ||
-       test "x$OPENJDK_TARGET_CPU" = xmipsel); then
-    BASIC_JVM_LIBS="$BASIC_JVM_LIBS -latomic"
+  # Atomic library
+  # 32-bit platforms needs fallback library for 8-byte atomic ops on Zero
+  if HOTSPOT_CHECK_JVM_VARIANT(zero); then
+    if test "x$OPENJDK_TARGET_OS" = xlinux &&
+        (test "x$OPENJDK_TARGET_CPU" = xarm ||
+         test "x$OPENJDK_TARGET_CPU" = xm68k ||
+         test "x$OPENJDK_TARGET_CPU" = xmips ||
+         test "x$OPENJDK_TARGET_CPU" = xmipsel ||
+         test "x$OPENJDK_TARGET_CPU" = xppc ||
+         test "x$OPENJDK_TARGET_CPU" = xsh); then
+      BASIC_JVM_LIBS="$BASIC_JVM_LIBS -latomic"
+    fi
   fi
 
   # perfstat lib


### PR DESCRIPTION
JDK-8256831 added the Zero linkage with libatomic for MIPS, but there are other 32-bit Zero platforms that need the same kind of treatment.

Additional testing:
 - [x]  linux-mipsel-zero-fastdebug build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259043](https://bugs.openjdk.java.net/browse/JDK-8259043): More Zero architectures need linkage with libatomic


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Contributors
 * Matthias Klose `<doko@openjdk.org>`

### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/76/head:pull/76`
`$ git checkout pull/76`
