### PR TITLE
8259213: Vector conversion with part > 0 is not getting intrinsic implementation

### DIFF
--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractShuffle.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractShuffle.java
@@ -120,6 +120,9 @@ abstract class AbstractShuffle<E> extends VectorShuffle<E> {
 
     @ForceInline
     public final VectorShuffle<E> checkIndexes() {
+        if (VectorIntrinsics.VECTOR_ACCESS_OOB_CHECK == 0) {
+            return this;
+        }
         // FIXME: vectorize this
         for (int index : reorder()) {
             if (index < 0) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractShuffle.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractShuffle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractVector.java
@@ -312,7 +312,7 @@ abstract class AbstractVector<E> extends Vector<E> {
             int origin = shapeChangeOrigin(vsp, rsp, false, part);
             //System.out.println("*** origin = "+origin+", part = "+part+", reinterpret");
             if (part > 0) {  // Expansion: slice first then cast.
-                return slice(origin, vsp.zero()).convert0('X', rsp);
+                return slice(origin).convert0('X', rsp);
             } else {  // Contraction: cast first then unslice.
                 return rsp.zero().slice(rsp.laneCount() - origin,
                                         convert0('X', rsp));
@@ -322,6 +322,9 @@ abstract class AbstractVector<E> extends Vector<E> {
 
     @Override
     public abstract AbstractVector<E> slice(int origin, Vector<E> v1);
+
+    @Override
+    public abstract AbstractVector<E> slice(int origin);
 
     /**
      * This is the template for Vector::convertShape, to be
@@ -365,7 +368,7 @@ abstract class AbstractVector<E> extends Vector<E> {
             int origin = shapeChangeOrigin(vsp, rsp, true, part);
             //System.out.println("*** origin = "+origin+", part = "+part+", lanewise");
             if (part > 0) {  // Expansion: slice first then cast.
-                return slice(origin, vsp.zero()).convert0(kind, rsp);
+                return slice(origin).convert0(kind, rsp);
             } else {  // Contraction: cast first then unslice.
                 return rsp.zero().slice(rsp.laneCount() - origin,
                                         convert0(kind, rsp));


### PR DESCRIPTION
Vector conversion with part > 0 is implemented using slice(origin, vector) instead of slice(origin).
The slice(origin) has intrinsic implementation whereas slice(origin, vector) doesn’t.
Slice(origin) is written using vector API methods like rearrange and blend which all have intrinsic implementations.
Also, VectorIntrinsics.VECTOR_ACCESS_OOB_CHECK code is missing from rearrange checkIndexes.

Please review this patch which fixes the above issue.

Best Regards,
Sandhya

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259213](https://bugs.openjdk.java.net/browse/JDK-8259213): Vector conversion with part > 0 is not getting intrinsic implementation


### Reviewers
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - **Reviewer**) ⚠️ Review applies to c283812f9f1aa12cfe5c7294e5e1c64980aaffe9


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/79/head:pull/79`
`$ git checkout pull/79`
