### PR TITLE
8257906: JFR: RecordingStream leaks memory

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ChunkParser.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ChunkParser.java
@@ -488,4 +488,16 @@ public final class ChunkParser {
     public boolean hasStaleMetadata() {
         return staleMetadata;
     }
+
+    public void resetCache() {
+        LongMap<Parser> ps = this.parsers;
+        if (ps != null) {
+            ps.forEach(p -> {
+                if (p instanceof EventParser) {
+                    EventParser ep = (EventParser) p;
+                    ep.resetCache();
+                }
+            });
+        }
+    }
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/EventDirectoryStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/EventDirectoryStream.java
@@ -159,6 +159,7 @@ public class EventDirectoryStream extends AbstractEventStream {
                     } else {
                         processUnordered(disp);
                     }
+                    currentParser.resetCache();
                     if (currentParser.getStartNanos() + currentParser.getChunkDuration() > filterEnd) {
                         close();
                         return;

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/EventFileStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/EventFileStream.java
@@ -102,6 +102,7 @@ public final class EventFileStream extends AbstractEventStream {
             } else {
                 processUnordered(disp);
             }
+            currentParser.resetCache();
             if (isClosed() || currentParser.isLastChunk()) {
                 return;
             }


### PR DESCRIPTION
Backport of JDK-8258478: JFR: RecordingStream leaks memory

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257906](https://bugs.openjdk.java.net/browse/JDK-8257906): JFR: RecordingStream leaks memory


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/81/head:pull/81`
`$ git checkout pull/81`
