### PR TITLE
8259224: (ann) getAnnotatedReceiverType should not parameterize owner(s) of statically nested classes

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/Executable.java
+++ b/src/java.base/share/classes/java/lang/reflect/Executable.java
@@ -707,7 +707,9 @@ public abstract class Executable extends AccessibleObject
         Class<?> ownerClass = c.getDeclaringClass();
         TypeVariable<?>[] typeVars = c.getTypeParameters();
 
-        if (ownerClass == null) { // base case
+        // base case, static nested classes, according to JLS 8.1.3, has no
+        // enclosing instance, therefore its owner is not generified.
+        if (ownerClass == null || Modifier.isStatic(c.getModifiers())) {
             if (typeVars.length == 0)
                 return c;
             else

--- a/test/jdk/java/lang/annotation/typeAnnotations/TestReceiverTypeOwnerType.java
+++ b/test/jdk/java/lang/annotation/typeAnnotations/TestReceiverTypeOwnerType.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8259224
+ * @summary A receiver type's owner type is of the correct type for nested classes.
+ */
+
+import java.lang.reflect.AnnotatedParameterizedType;
+import java.lang.reflect.AnnotatedType;
+
+public class TestReceiverTypeOwnerType<T> {
+
+    public static void main(String[] args) throws Exception {
+        AnnotatedType nested = Class.forName(TestReceiverTypeOwnerType.class.getTypeName() + "$Nested").getMethod("method").getAnnotatedReceiverType();
+        if (!(nested instanceof AnnotatedParameterizedType)) {
+            throw new AssertionError();
+        } else if (!(nested.getAnnotatedOwnerType() instanceof AnnotatedParameterizedType)) {
+            throw new AssertionError();
+        }
+        AnnotatedType inner = Inner.class.getMethod("method").getAnnotatedReceiverType();
+        if (inner instanceof AnnotatedParameterizedType) {
+            throw new AssertionError();
+        } else if (inner.getAnnotatedOwnerType() instanceof AnnotatedParameterizedType) {
+            throw new AssertionError();
+        }
+        AnnotatedType nestedInner = GenericInner.class.getMethod("method").getAnnotatedReceiverType();
+        if (!(nestedInner instanceof AnnotatedParameterizedType)) {
+            throw new AssertionError();
+        } else if (nestedInner.getAnnotatedOwnerType() instanceof AnnotatedParameterizedType) {
+            throw new AssertionError();
+        }
+    }
+
+    public class Nested {
+        public void method(TestReceiverTypeOwnerType<T>.Nested this) { }
+    }
+
+    public static class Inner {
+        public void method(TestReceiverTypeOwnerType.Inner this) { }
+    }
+
+    public static class GenericInner<S> {
+        public void method(TestReceiverTypeOwnerType.GenericInner<S> this) { }
+    }
+}


### PR DESCRIPTION
This change avoid that owner types of static nested classes are returned as parameterized types.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259224](https://bugs.openjdk.java.net/browse/JDK-8259224): (ann) getAnnotatedReceiverType should not parameterize owner(s) of statically nested classes


### Reviewers
 * [Joel Borggrén-Franck](https://openjdk.java.net/census#jfranck) (@jbf - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/82/head:pull/82`
`$ git checkout pull/82`
