### PR TITLE
8259027: NullPointerException in makeMappedSegment due to NULL Unmapper when length of segment is 0

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MappedMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MappedMemorySegmentImpl.java
@@ -57,29 +57,6 @@ public class MappedMemorySegmentImpl extends NativeMemorySegmentImpl {
         this.unmapper = unmapper;
     }
 
-    static final MappedMemorySegmentImpl EMPTY_MAPPING = new MappedMemorySegmentImpl(0, null, 0, MemorySegment.ALL_ACCESS,
-            MemoryScope.createConfined(null, MemoryScope.DUMMY_CLEANUP_ACTION, null)) {
-        @Override
-        public void load() {
-            // do nothing
-        }
-
-        @Override
-        public void unload() {
-            // do nothing
-        }
-
-        @Override
-        public boolean isLoaded() {
-            return true;
-        }
-
-        @Override
-        public void force() {
-            // do nothing
-        }
-    };
-
     @Override
     ByteBuffer makeByteBuffer() {
         return nioAccess.newMappedByteBuffer(unmapper, min, (int)length, null, this);
@@ -148,7 +125,7 @@ public class MappedMemorySegmentImpl extends NativeMemorySegmentImpl {
                 return new MappedMemorySegmentImpl(unmapperProxy.address(), unmapperProxy, bytesSize,
                         modes, scope);
             } else {
-                return EMPTY_MAPPING;
+                return new EmptyMappedMemorySegmentImpl();
             }
         }
     }
@@ -162,4 +139,32 @@ public class MappedMemorySegmentImpl extends NativeMemorySegmentImpl {
             throw new UnsupportedOperationException("Unsupported map mode: " + mapMode);
         }
     }
+
+    static class EmptyMappedMemorySegmentImpl extends MappedMemorySegmentImpl {
+
+        public EmptyMappedMemorySegmentImpl() {
+            super(0, null, 0, MemorySegment.ALL_ACCESS,
+                    MemoryScope.createConfined(null, MemoryScope.DUMMY_CLEANUP_ACTION, null));
+        }
+
+        @Override
+        public void load() {
+            // do nothing
+        }
+
+        @Override
+        public void unload() {
+            // do nothing
+        }
+
+        @Override
+        public boolean isLoaded() {
+            return true;
+        }
+
+        @Override
+        public void force() {
+            // do nothing
+        }
+    };
 }

--- a/test/jdk/java/foreign/TestByteBuffer.java
+++ b/test/jdk/java/foreign/TestByteBuffer.java
@@ -469,9 +469,21 @@ public class TestByteBuffer {
         File f = new File("testPos1.out");
         f.createNewFile();
         f.deleteOnExit();
+        //RW
         try (MemorySegment segment = MemorySegment.mapFile(f.toPath(), 0L, 0L, FileChannel.MapMode.READ_WRITE)) {
             assertEquals(segment.byteSize(), 0);
             assertEquals(segment.isMapped(), true);
+            assertTrue((segment.accessModes() & (READ | WRITE)) == (READ | WRITE));
+            MappedMemorySegments.force(segment);
+            MappedMemorySegments.load(segment);
+            MappedMemorySegments.isLoaded(segment);
+            MappedMemorySegments.unload(segment);
+        }
+        //RO
+        try (MemorySegment segment = MemorySegment.mapFile(f.toPath(), 0L, 0L, FileChannel.MapMode.READ_ONLY)) {
+            assertEquals(segment.byteSize(), 0);
+            assertEquals(segment.isMapped(), true);
+            assertTrue((segment.accessModes() & (READ | WRITE)) == READ);
             MappedMemorySegments.force(segment);
             MappedMemorySegments.load(segment);
             MappedMemorySegments.isLoaded(segment);

--- a/test/jdk/java/foreign/TestByteBuffer.java
+++ b/test/jdk/java/foreign/TestByteBuffer.java
@@ -464,12 +464,18 @@ public class TestByteBuffer {
         MemorySegment.mapFile(f.toPath(), -1, 1, FileChannel.MapMode.READ_WRITE);
     }
 
+    @Test
     public void testMapZeroSize() throws IOException {
         File f = new File("testPos1.out");
         f.createNewFile();
         f.deleteOnExit();
         try (MemorySegment segment = MemorySegment.mapFile(f.toPath(), 0L, 0L, FileChannel.MapMode.READ_WRITE)) {
             assertEquals(segment.byteSize(), 0);
+            assertEquals(segment.isMapped(), true);
+            MappedMemorySegments.force(segment);
+            MappedMemorySegments.load(segment);
+            MappedMemorySegments.isLoaded(segment);
+            MappedMemorySegments.unload(segment);
         }
     }
 


### PR DESCRIPTION
When the size of the memory map is zero, FileChannelImpl returns a `null` Unmapper - this creates issues to the mapped memory segment implementation.

To fix, I've created an empty mapped segment class which is initialized to sensible defaults, and whose implenentation of force/load etc. do nothing.

We already had a test for this condition - but the test was missing the `@Test` annotation, so it was not run! I've now beefed up the test a bit to make sure that mapped segment operations do not throw.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259027](https://bugs.openjdk.java.net/browse/JDK-8259027): NullPointerException in makeMappedSegment due to NULL Unmapper when length of segment is 0


### Reviewers
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**)
 * [Uwe Schindler](https://openjdk.java.net/census#uschindler) (@uschindler - Author)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/83/head:pull/83`
`$ git checkout pull/83`
