### PR TITLE
8259075: Update the copyright notice in the files generated by CLDR Converter tool

### DIFF
--- a/make/jdk/src/classes/build/tools/cldrconverter/CopyrightHeaders.java
+++ b/make/jdk/src/classes/build/tools/cldrconverter/CopyrightHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,14 +41,13 @@ class CopyrightHeaders {
         " * Copyright (c) 2012, %d, Oracle and/or its affiliates. All rights reserved.\n" +
         " */\n";
 
-    // Last updated:  - 6/06/2016, 1:42:31 PM
+    // Last updated:  - 1/04/2021
     private static final String UNICODE =
         "/*\n" +
         " * COPYRIGHT AND PERMISSION NOTICE\n" +
         " *\n" +
-        " * Copyright (C) 1991-2016 Unicode, Inc. All rights reserved.\n" +
-        " * Distributed under the Terms of Use in \n" +
-        " * http://www.unicode.org/copyright.html.\n" +
+        " * Copyright (c) 1991-2020 Unicode, Inc. All rights reserved.\n" +
+        " * Distributed under the Terms of Use in https://www.unicode.org/copyright.html.\n" +
         " *\n" +
         " * Permission is hereby granted, free of charge, to any person obtaining\n" +
         " * a copy of the Unicode data files and any associated documentation\n" +
@@ -57,14 +56,11 @@ class CopyrightHeaders {
         " * without restriction, including without limitation the rights to use,\n" +
         " * copy, modify, merge, publish, distribute, and/or sell copies of\n" +
         " * the Data Files or Software, and to permit persons to whom the Data Files\n" +
-        " * or Software are furnished to do so, provided that\n" +
-        " * (a) this copyright and permission notice appear with all copies \n" +
-        " * of the Data Files or Software,\n" +
-        " * (b) this copyright and permission notice appear in associated \n" +
-        " * documentation, and\n" +
-        " * (c) there is clear notice in each modified Data File or in the Software\n" +
-        " * as well as in the documentation associated with the Data File(s) or\n" +
-        " * Software that the data or software has been modified.\n" +
+        " * or Software are furnished to do so, provided that either\n" +
+        " * (a) this copyright and permission notice appear with all copies\n" +
+        " * of the Data Files or Software, or\n" +
+        " * (b) this copyright and permission notice appear in associated\n" +
+        " * Documentation.\n" +
         " *\n" +
         " * THE DATA FILES AND SOFTWARE ARE PROVIDED \"AS IS\", WITHOUT WARRANTY OF\n" +
         " * ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE\n" +


### PR DESCRIPTION
Please review this copyright notice update in the CLDR Converter tool. It is now synched with src/java.base/share/legal/cldr.md file.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259075](https://bugs.openjdk.java.net/browse/JDK-8259075): Update the copyright notice in the files generated by CLDR Converter tool


### Reviewers
 * [Joe Wang](https://openjdk.java.net/census#joehw) (@JoeWang-Java - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/85/head:pull/85`
`$ git checkout pull/85`
