### PR TITLE
8250903: jdk/jfr/javaagent/TestLoadedAgent.java fails with Mismatch in TestEvent count

### DIFF
--- a/test/jdk/jdk/jfr/javaagent/EventEmitterAgent.java
+++ b/test/jdk/jdk/jfr/javaagent/EventEmitterAgent.java
@@ -35,7 +35,7 @@ import jdk.jfr.consumer.RecordingFile;
 import jdk.test.lib.Asserts;
 import jdk.test.lib.jfr.EventNames;
 
-// Java agent that emits in multiple threads
+// Java agent that emits events
 public class EventEmitterAgent {
 
     private static final long EVENTS = 150_000;


### PR DESCRIPTION
Hi,

Could I have review of a test fix? 

Tests fails intermittently, most likely due to JFR not able to keep up with the high event rate. Purpose of the test is not to stress JFR, so events are now only emitted from one thread. I also changed the assert, so it is easier to see how much off the count is. 

Tested by running it 100 times without failure.

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8250903](https://bugs.openjdk.java.net/browse/JDK-8250903): jdk/jfr/javaagent/TestLoadedAgent.java fails with Mismatch in TestEvent count


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**) ⚠️ Review applies to 5271aab2bb931e4f1f5b2070d507a4515514817c


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/87/head:pull/87`
`$ git checkout pull/87`
