### PR TITLE
8259227: C2 crashes with SIGFPE due to a division that floats above its zero check

### DIFF
--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -1451,7 +1451,6 @@ public:
   // Mark an IfNode as being dominated by a prior test,
   // without actually altering the CFG (and hence IDOM info).
   void dominated_by( Node *prevdom, Node *iff, bool flip = false, bool exclude_loop_predicate = false );
-  bool no_dependent_zero_check(Node* n) const;
 
   // Split Node 'n' through merge point
   Node *split_thru_region( Node *n, Node *region );

--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -283,7 +283,7 @@ void PhaseIdealLoop::dominated_by( Node *prevdom, Node *iff, bool flip, bool exc
   for (DUIterator_Fast imax, i = dp->fast_outs(imax); i < imax; i++) {
     Node* cd = dp->fast_out(i); // Control-dependent node
     // Do not rewire Div and Mod nodes which could have a zero divisor to avoid skipping their zero check.
-    if (cd->depends_only_on_test() && no_dependent_zero_check(cd)) {
+    if (cd->depends_only_on_test() && _igvn.no_dependent_zero_check(cd)) {
       assert(cd->in(0) == dp, "");
       _igvn.replace_input_of(cd, 0, prevdom);
       set_early_ctrl(cd, false);
@@ -300,25 +300,6 @@ void PhaseIdealLoop::dominated_by( Node *prevdom, Node *iff, bool flip, bool exc
       --imax;
     }
   }
-}
-
-// Check if the type of a divisor of a Div or Mod node includes zero.
-bool PhaseIdealLoop::no_dependent_zero_check(Node* n) const {
-  switch (n->Opcode()) {
-    case Op_DivI:
-    case Op_ModI: {
-      // Type of divisor includes 0?
-      const TypeInt* type_divisor = _igvn.type(n->in(2))->is_int();
-      return (type_divisor->_hi < 0 || type_divisor->_lo > 0);
-    }
-    case Op_DivL:
-    case Op_ModL: {
-      // Type of divisor includes 0?
-      const TypeLong* type_divisor = _igvn.type(n->in(2))->is_long();
-      return (type_divisor->_hi < 0 || type_divisor->_lo > 0);
-    }
-  }
-  return true;
 }
 
 //------------------------------has_local_phi_input----------------------------

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -1659,6 +1659,25 @@ void PhaseIterGVN::remove_speculative_types()  {
   _table.check_no_speculative_types();
 }
 
+// Check if the type of a divisor of a Div or Mod node includes zero.
+bool PhaseIterGVN::no_dependent_zero_check(Node* n) const {
+  switch (n->Opcode()) {
+    case Op_DivI:
+    case Op_ModI: {
+      // Type of divisor includes 0?
+      const TypeInt* type_divisor = type(n->in(2))->is_int();
+      return (type_divisor->_hi < 0 || type_divisor->_lo > 0);
+    }
+    case Op_DivL:
+    case Op_ModL: {
+      // Type of divisor includes 0?
+      const TypeLong* type_divisor = type(n->in(2))->is_long();
+      return (type_divisor->_hi < 0 || type_divisor->_lo > 0);
+    }
+  }
+  return true;
+}
+
 //=============================================================================
 #ifndef PRODUCT
 uint PhaseCCP::_total_invokes   = 0;

--- a/src/hotspot/share/opto/phaseX.hpp
+++ b/src/hotspot/share/opto/phaseX.hpp
@@ -546,6 +546,7 @@ public:
   }
 
   bool is_dominator(Node *d, Node *n) { return is_dominator_helper(d, n, false); }
+  bool no_dependent_zero_check(Node* n) const;
 
 #ifndef PRODUCT
 protected:

--- a/test/hotspot/jtreg/compiler/loopopts/TestDivZeroDominatedBy.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestDivZeroDominatedBy.java
@@ -24,11 +24,14 @@
 
 /*
  * @test
+ * @key stress randomness
  * @bug 8259227
  * @summary Verify that zero check is executed before division/modulo operation.
  * @requires vm.compiler2.enabled
  * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:CompileOnly=compiler/loopopts/TestDivZeroDominatedBy::test
  *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM -XX:StressSeed=917280111 compiler.loopopts.TestDivZeroDominatedBy
+ * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:CompileOnly=compiler/loopopts/TestDivZeroDominatedBy::test
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM compiler.loopopts.TestDivZeroDominatedBy
  */
 
 package compiler.loopopts;

--- a/test/hotspot/jtreg/compiler/loopopts/TestDivZeroDominatedBy.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestDivZeroDominatedBy.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @bug 8259227
+ * @summary Verify that zero check is executed before division/modulo operation.
+ * @requires vm.compiler2.enabled
+ * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:CompileOnly=compiler/loopopts/TestDivZeroDominatedBy::test
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM -XX:StressSeed=917280111 compiler.loopopts.TestDivZeroDominatedBy
+ */
+
+package compiler.loopopts;
+
+public class TestDivZeroDominatedBy {
+
+    public static int iFld = 1;
+    public static int iFld1 = 2;
+    public static int iFld2 = 3;
+    public static int iArrFld[] = new int[10];
+    public static double dFld = 1.0;
+
+    public static void test() {
+        int x = 1;
+        int y = 2;
+        int z = 3;
+
+        iFld = y;
+        iArrFld[5] += iFld1;
+        int i = 1;
+        do {
+            for (int j = 0; j < 10; j++) {
+                iFld2 += iFld2;
+                iFld1 = iFld2;
+                int k = 1;
+                do {
+                    iArrFld[k] = y;
+                    z = iFld2;
+                    dFld = x;
+                    try {
+                        y = iArrFld[k];
+                        iArrFld[8] = 5;
+                        iFld = (100 / z);
+                    } catch (ArithmeticException a_e) {}
+                } while (++k < 2);
+            }
+        } while (++i < 10);
+    }
+
+    public static void main(String[] strArr) {
+        test();
+    }
+}
+

--- a/test/hotspot/jtreg/compiler/loopopts/TestDivZeroWithSplitIf.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestDivZeroWithSplitIf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,11 +24,14 @@
 
 /*
  * @test
+ * @key stress randomness
  * @bug 8257822
  * @summary Verify that zero check is executed before division/modulo operation.
  * @requires vm.compiler2.enabled
  * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:CompileOnly=compiler/loopopts/TestDivZeroWithSplitIf::test
  *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM -XX:StressSeed=873732072 compiler.loopopts.TestDivZeroWithSplitIf
+ * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:CompileOnly=compiler/loopopts/TestDivZeroWithSplitIf::test
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM compiler.loopopts.TestDivZeroWithSplitIf
  */
 
 package compiler.loopopts;


### PR DESCRIPTION
This bug is very similar to [JDK-8257822](https://bugs.openjdk.java.net/browse/JDK-8257822). In this testcase, a `Div` node has no longer its zero check as direct control input and is later moved before the zero check by `IfNode::dominated_by()` which updates all data nodes to a dominating `If` (in JDK-8257822 it was done by `PhaseIdealLoop::dominated_by()`) .

I suggest to use the same fix for `IfNode::dominated_by()` as for `PhaseIdealLoop::dominated_by()` in JDK-8257822 to only move data nodes to the dominating `If` if it is not a `Div` or `Mod` node that could have a zero divisor (i.e. a zero check).

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259227](https://bugs.openjdk.java.net/browse/JDK-8259227): C2 crashes with SIGFPE due to a division that floats above its zero check


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to 4273fcfba59d1826a9bf51a9a6de0e49f3393686
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/89/head:pull/89`
`$ git checkout pull/89`
