### PR TITLE
8259028: ClassCastException when using custom filesystem with wrapper FileChannel impl

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
@@ -876,10 +876,9 @@ allocateNative(bytesSize, 1);
      * @param mapMode a file mapping mode, see {@link FileChannel#map(FileChannel.MapMode, long, long)}; the chosen mapping mode
      *                might affect the behavior of the returned memory mapped segment (see {@link MappedMemorySegments#force(MemorySegment)}).
      * @return a new confined mapped memory segment.
-     * @throws IllegalArgumentException if {@code bytesOffset < 0}.
-     * @throws IllegalArgumentException if {@code bytesSize < 0}.
-     * @throws UnsupportedOperationException if an unsupported map mode is specified, or if the {@code path} is associated
-     * with a provider that does not support creating file channels.
+     * @throws IllegalArgumentException if {@code bytesOffset < 0}, {@code bytesSize < 0}, or if {@code path} is associated
+     * with a custom file system provider.
+     * @throws UnsupportedOperationException if an unsupported map mode is specified.
      * @throws IOException if the specified path does not point to an existing file, or if some other I/O error occurs.
      * @throws  SecurityException If a security manager is installed and it denies an unspecified permission required by the implementation.
      * In the case of the default provider, the {@link SecurityManager#checkRead(String)} method is invoked to check

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
@@ -876,8 +876,8 @@ allocateNative(bytesSize, 1);
      * @param mapMode a file mapping mode, see {@link FileChannel#map(FileChannel.MapMode, long, long)}; the chosen mapping mode
      *                might affect the behavior of the returned memory mapped segment (see {@link MappedMemorySegments#force(MemorySegment)}).
      * @return a new confined mapped memory segment.
-     * @throws IllegalArgumentException if {@code bytesOffset < 0}, {@code bytesSize < 0}, or if {@code path} is associated
-     * with a custom file system provider.
+     * @throws IllegalArgumentException if {@code bytesOffset < 0}, {@code bytesSize < 0}, or if {@code path} is not associated
+     * with the default file system.
      * @throws UnsupportedOperationException if an unsupported map mode is specified.
      * @throws IOException if the specified path does not point to an existing file, or if some other I/O error occurs.
      * @throws  SecurityException If a security manager is installed and it denies an unspecified permission required by the implementation.

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MappedMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MappedMemorySegmentImpl.java
@@ -34,6 +34,8 @@ import java.io.FileDescriptor;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
 import java.nio.file.OpenOption;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -114,8 +116,13 @@ public class MappedMemorySegmentImpl extends NativeMemorySegmentImpl {
         Objects.requireNonNull(mapMode);
         if (bytesSize < 0) throw new IllegalArgumentException("Requested bytes size must be >= 0.");
         if (bytesOffset < 0) throw new IllegalArgumentException("Requested bytes offset must be >= 0.");
-        try (FileChannelImpl channelImpl = (FileChannelImpl)FileChannel.open(path, openOptions(mapMode))) {
-            UnmapperProxy unmapperProxy = channelImpl.mapInternal(mapMode, bytesOffset, bytesSize);
+        FileSystem fs = path.getFileSystem();
+        if (fs != FileSystems.getDefault() ||
+                fs.getClass().getModule() != Object.class.getModule()) {
+            throw new IllegalArgumentException("Unsupported file system");
+        }
+        try (FileChannel channelImpl = FileChannel.open(path, openOptions(mapMode))) {
+            UnmapperProxy unmapperProxy = ((FileChannelImpl)channelImpl).mapInternal(mapMode, bytesOffset, bytesSize);
             int modes = defaultAccessModes(bytesSize);
             if (mapMode == FileChannel.MapMode.READ_ONLY) {
                 modes &= ~WRITE;

--- a/test/jdk/java/foreign/TestByteBuffer.java
+++ b/test/jdk/java/foreign/TestByteBuffer.java
@@ -25,6 +25,7 @@
  * @test
  * @modules java.base/sun.nio.ch
  *          jdk.incubator.foreign/jdk.internal.foreign
+ *          java.base/jdk.internal.jrtfs
  * @run testng/othervm -Dforeign.restricted=permit TestByteBuffer
  */
 
@@ -47,6 +48,7 @@ import java.lang.ref.WeakReference;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.net.URI;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -75,6 +77,7 @@ import java.util.stream.Stream;
 import jdk.internal.foreign.HeapMemorySegmentImpl;
 import jdk.internal.foreign.MappedMemorySegmentImpl;
 import jdk.internal.foreign.NativeMemorySegmentImpl;
+import jdk.internal.jrtfs.JrtFileSystemProvider;
 import org.testng.SkipException;
 import org.testng.annotations.*;
 import sun.nio.ch.DirectBuffer;
@@ -489,6 +492,12 @@ public class TestByteBuffer {
             MappedMemorySegments.isLoaded(segment);
             MappedMemorySegments.unload(segment);
         }
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testMapCustomPath() throws IOException {
+        Path path = new JrtFileSystemProvider().getPath(URI.create("JRT:/"));
+        MemorySegment.mapFile(path, 0L, 0L, FileChannel.MapMode.READ_WRITE);
     }
 
     @Test(dataProvider="resizeOps")

--- a/test/jdk/java/foreign/TestByteBuffer.java
+++ b/test/jdk/java/foreign/TestByteBuffer.java
@@ -25,7 +25,6 @@
  * @test
  * @modules java.base/sun.nio.ch
  *          jdk.incubator.foreign/jdk.internal.foreign
- *          java.base/jdk.internal.jrtfs
  * @run testng/othervm -Dforeign.restricted=permit TestByteBuffer
  */
 
@@ -77,7 +76,6 @@ import java.util.stream.Stream;
 import jdk.internal.foreign.HeapMemorySegmentImpl;
 import jdk.internal.foreign.MappedMemorySegmentImpl;
 import jdk.internal.foreign.NativeMemorySegmentImpl;
-import jdk.internal.jrtfs.JrtFileSystemProvider;
 import org.testng.SkipException;
 import org.testng.annotations.*;
 import sun.nio.ch.DirectBuffer;
@@ -496,7 +494,7 @@ public class TestByteBuffer {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testMapCustomPath() throws IOException {
-        Path path = new JrtFileSystemProvider().getPath(URI.create("JRT:/"));
+        Path path = Path.of(URI.create("jrt:/"));
         MemorySegment.mapFile(path, 0L, 0L, FileChannel.MapMode.READ_WRITE);
     }
 


### PR DESCRIPTION
This patch tweaks `MemorySegment::mapFile` so that it will throw `IllegalArgumentException` whenever the path to be mapped is associated with a custom file system provider.

The check in the implementation is heavily borrowed by what `UnixDomainSocketAddress::of(Path)` does (thanks Alan for the tip!). Not only we have to check if file system is the default one, but also if the default FS belongs to java.base (since that can be overridden).

The test simply check that paths coming from the (internal) JRT file system are not supported by the factory.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259028](https://bugs.openjdk.java.net/browse/JDK-8259028): ClassCastException when using custom filesystem with wrapper FileChannel impl


### Reviewers
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Uwe Schindler](https://openjdk.java.net/census#uschindler) (@uschindler - Author)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/90/head:pull/90`
`$ git checkout pull/90`
