### PR TITLE
8259312: VerifyCACerts.java fails as soneraclass2ca cert will expire in 90 days

### DIFF
--- a/test/jdk/sun/security/lib/cacerts/VerifyCACerts.java
+++ b/test/jdk/sun/security/lib/cacerts/VerifyCACerts.java
@@ -27,7 +27,7 @@
  * @bug 8189131 8198240 8191844 8189949 8191031 8196141 8204923 8195774 8199779
  *      8209452 8209506 8210432 8195793 8216577 8222089 8222133 8222137 8222136
  *      8223499 8225392 8232019 8234245 8233223 8225068 8225069 8243321 8243320
- *      8243559 8225072 8258630
+ *      8243559 8225072 8258630 8259312
  * @summary Check root CA entries in cacerts file
  */
 import java.io.ByteArrayInputStream;
@@ -262,6 +262,8 @@ public class VerifyCACerts {
             add("luxtrustglobalrootca [jdk]");
             // Valid until: Wed Mar 17 11:33:33 PDT 2021
             add("quovadisrootca [jdk]");
+            // Valid until: Tue Apr 06 00:29:40 PDT 2021
+            add("soneraclass2ca [jdk]");
         }
     };
 


### PR DESCRIPTION
…in 90 days

Reviewed-by: mullan

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8259312](https://bugs.openjdk.java.net/browse/JDK-8259312): VerifyCACerts.java fails as soneraclass2ca cert will expire in 90 days


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/92/head:pull/92`
`$ git checkout pull/92`
