### PR TITLE
8258484: AIX build fails in Harfbuzz with XLC 16.01.0000.0006

### DIFF
--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -474,6 +474,11 @@ else
     #
 
   LIBHARFBUZZ_OPTIMIZATION := HIGH
+  # Early re-canonizing has to be disabled to workaround an internal XlC compiler error
+  # when building libharfbuzz
+  ifeq ($(call isTargetOs, aix), true)
+    LIBHARFBUZZ_CFLAGS += -qdebug=necan
+  endif
 
   LIBHARFBUZZ_CFLAGS += $(X_CFLAGS) -DLE_STANDALONE -DHEADLESS
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8258484](https://bugs.openjdk.java.net/browse/JDK-8258484): AIX build fails in Harfbuzz with XLC 16.01.0000.0006


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/95/head:pull/95`
`$ git checkout pull/95`
