### PR TITLE
8259014: (so) ServerSocketChannel.bind(UnixDomainSocketAddress)/SocketChannel.bind(UnixDomainSocketAddress) will have unknown user and group owner (win)

### DIFF
--- a/src/java.base/windows/native/libnio/ch/UnixDomainSockets.c
+++ b/src/java.base/windows/native/libnio/ch/UnixDomainSockets.c
@@ -92,7 +92,16 @@ Java_sun_nio_ch_UnixDomainSockets_socketSupported(JNIEnv *env, jclass cl)
         return JNI_FALSE;
     }
     closesocket(s);
-    return JNI_TRUE;
+
+    /* Check for build 18362 or newer, due to Windows bug described in 8259014 */
+
+    OSVERSIONINFOEXW osvi = { sizeof(osvi), 0, 0, 0, 0, {0}, 0, 0 };
+    DWORDLONG cond_mask = 0;
+
+    VER_SET_CONDITION(cond_mask, VER_BUILDNUMBER, VER_GREATER_EQUAL);
+    osvi.dwBuildNumber  = 18362; // Windows 10 (1903) or newer
+
+    return VerifyVersionInfoW(&osvi, VER_BUILDNUMBER, cond_mask) != 0;
 }
 
 JNIEXPORT jint JNICALL


### PR DESCRIPTION
Continuing this review on a new PR (for jdk16). I have also updated the implementation to use VerifyVersionInfo.

Thanks,
Michael

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259014](https://bugs.openjdk.java.net/browse/JDK-8259014): (so) ServerSocketChannel.bind(UnixDomainSocketAddress)/SocketChannel.bind(UnixDomainSocketAddress) will have unknown user and group owner (win)


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/96/head:pull/96`
`$ git checkout pull/96`
