### PR TITLE
8259380: Correct pretouch chunk size to cap with actual page size

### DIFF
--- a/src/hotspot/share/gc/shared/pretouchTask.cpp
+++ b/src/hotspot/share/gc/shared/pretouchTask.cpp
@@ -64,7 +64,7 @@ void PretouchTask::work(uint worker_id) {
 
 void PretouchTask::pretouch(const char* task_name, char* start_address, char* end_address,
                             size_t page_size, WorkGang* pretouch_gang) {
-  // Chunk size should be at least (unmodified) page size as using multiple threads 
+  // Chunk size should be at least (unmodified) page size as using multiple threads
   // pretouch on a single chunk can decrease performance.
   size_t chunk_size = MAX2(PretouchTask::chunk_size(), page_size);
 #ifdef LINUX

--- a/src/hotspot/share/gc/shared/pretouchTask.cpp
+++ b/src/hotspot/share/gc/shared/pretouchTask.cpp
@@ -65,7 +65,7 @@ void PretouchTask::work(uint worker_id) {
 void PretouchTask::pretouch(const char* task_name, char* start_address, char* end_address,
                             size_t page_size, WorkGang* pretouch_gang) {
   // Chunk size should be at least (unmodified) page size as using multiple threads
-  // pretouch on a single chunk can decrease performance.
+  // pretouch on a single page can decrease performance.
   size_t chunk_size = MAX2(PretouchTask::chunk_size(), page_size);
 #ifdef LINUX
   // When using THP we need to always pre-touch using small pages as the OS will

--- a/src/hotspot/share/gc/shared/pretouchTask.cpp
+++ b/src/hotspot/share/gc/shared/pretouchTask.cpp
@@ -64,13 +64,16 @@ void PretouchTask::work(uint worker_id) {
 
 void PretouchTask::pretouch(const char* task_name, char* start_address, char* end_address,
                             size_t page_size, WorkGang* pretouch_gang) {
-
+  // The chunk size should cap with the input page size which probably stands for
+  // large pages size if UseLargePages was set, otherwise processing chunks with
+  // much smaller size inside large size pages would hurt performance.
+  // Revising page_size should be placed after having decided the proper chuck_size.
+  size_t chunk_size = MAX2(PretouchTask::chunk_size(), page_size);
 #ifdef LINUX
   // When using THP we need to always pre-touch using small pages as the OS will
   // initially always use small pages.
   page_size = UseTransparentHugePages ? (size_t)os::vm_page_size() : page_size;
 #endif
-  size_t chunk_size = MAX2(PretouchTask::chunk_size(), page_size);
 
   PretouchTask task(task_name, start_address, end_address, page_size, chunk_size);
   size_t total_bytes = pointer_delta(end_address, start_address, sizeof(char));

--- a/src/hotspot/share/gc/shared/pretouchTask.cpp
+++ b/src/hotspot/share/gc/shared/pretouchTask.cpp
@@ -64,10 +64,8 @@ void PretouchTask::work(uint worker_id) {
 
 void PretouchTask::pretouch(const char* task_name, char* start_address, char* end_address,
                             size_t page_size, WorkGang* pretouch_gang) {
-  // The chunk size should cap with the input page size which probably stands for
-  // large pages size if UseLargePages was set, otherwise processing chunks with
-  // much smaller size inside large size pages would hurt performance.
-  // Revising page_size should be placed after having decided the proper chuck_size.
+  // Chunk size should be at least (unmodified) page size as using multiple threads 
+  // pretouch on a single chunk can decrease performance.
   size_t chunk_size = MAX2(PretouchTask::chunk_size(), page_size);
 #ifdef LINUX
   // When using THP we need to always pre-touch using small pages as the OS will


### PR DESCRIPTION
This is actually a regression, with regards to JVM startup time extreme slowdown, initially found at an aarch64 platform (Ampere Altra core).

The chunk size of pretouching should cap with the input page size which probably stands for large pages size if UseLargePages was set, otherwise processing chunks with much smaller size inside large size pages would hurt performance.

This issue was introduced during a refactor on chunk calculations JDK-8254972 (2c7fc85) but did not cause any problem immediately since the default PreTouchParallelChunkSize for all platforms are 1GB which can cover all popular sizes of large pages in use by most kernel variations. Later on, JDK-8254699 (805d058) set default 4MB for Linux platform, which is helpful to speed up startup time for some platforms. For example, most x64, since the popular default large page size (e.g. CentOS) is 2MB. In contrast, most default large page size with aarch64 platforms/kernels (e.g. CentOS) are 512MB, so using the 4MB chunk size to do page walk through the pages inside 512MB large page hurt performance of startup time.

In addition, there will be a similar problem if we set -XX:PreTouchParallelChunkSize=4k at a x64 Linux platform, the startup slowdown will show as well.

Tests:
https://bugs.openjdk.java.net/secure/attachment/92623/pretouch_chunk_size_fix_testing.txt
The 4 before-after comparisons show the JVM startup time go back to normal.
1). 33.381s to 0.870s
2). 20.333s to 2.740s
3). 15.090s to 6.268s
4). 38.983s to 6.709s
(Use the start time of pretouching the first Survivor space as a rough measurement, while \time, or GCTraceTime can generate similar results)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259380](https://bugs.openjdk.java.net/browse/JDK-8259380): Correct pretouch chunk size to cap with actual page size


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/97/head:pull/97`
`$ git checkout pull/97`
