### PR TITLE
8259061: C2: assert(found) failed: memory-writing node is not placed in its original loop or an ancestor of it

### DIFF
--- a/src/hotspot/share/opto/block.cpp
+++ b/src/hotspot/share/opto/block.cpp
@@ -1221,26 +1221,6 @@ void PhaseCFG::verify() const {
       if (j >= 1 && n->is_Mach() && n->as_Mach()->ideal_Opcode() == Op_CreateEx) {
         assert(j == 1 || block->get_node(j-1)->is_Phi(), "CreateEx must be first instruction in block");
       }
-      // Verify that memory-writing nodes (such as stores and calls) are placed
-      // in their original loop L (given by the control input) or in an ancestor
-      // of L. This is guaranteed by the freq. estimation model for reducible
-      // CFGs, and by special handling in PhaseCFG::schedule_late() otherwise.
-      if (n->is_Mach() && n->bottom_type()->has_memory() && n->in(0) != NULL) {
-        Block* original_block = find_block_for_node(n->in(0));
-        assert(original_block != NULL, "missing block for memory-writing node");
-        CFGLoop* original_or_ancestor = original_block->_loop;
-        assert(block->_loop != NULL && original_or_ancestor != NULL, "no loop");
-        bool found = false;
-        do {
-          if (block->_loop == original_or_ancestor) {
-            found = true;
-            break;
-          }
-          original_or_ancestor = original_or_ancestor->parent();
-        } while (original_or_ancestor != NULL);
-        assert(found, "memory-writing node is not placed in its original loop "
-                      "or an ancestor of it");
-      }
       if (n->needs_anti_dependence_check()) {
         verify_anti_dependences(block, n);
       }


### PR DESCRIPTION
Remove assertion that is too general, that is, it can fail on compilations where C2 generates correct code otherwise.

The assertion was introduced in [JDK-8255763](https://bugs.openjdk.java.net/browse/JDK-8255763) to prevent potential miscompilations in the case of irreducible CFGs, and will be reconsidered in [JDK-8258894](https://bugs.openjdk.java.net/browse/JDK-8258894) where the general case is addressed.

Tested by building (release and debug) on different platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259061](https://bugs.openjdk.java.net/browse/JDK-8259061): C2: assert(found) failed: memory-writing node is not placed in its original loop or an ancestor of it


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/101/head:pull/101`
`$ git checkout pull/101`
