### PR TITLE
8259560: Zero m68k: "static assertion failed: align" after JDK-8252049

### DIFF
--- a/src/hotspot/share/ci/ciMethodData.cpp
+++ b/src/hotspot/share/ci/ciMethodData.cpp
@@ -202,7 +202,12 @@ void ciMethodData::load_data() {
   // _extra_data_size = extra_data_limit - extra_data_base
   // total_size = _data_size + _extra_data_size
   // args_data_limit = data_base + total_size - parameter_data_size
+
+#ifndef ZERO
+  // Some Zero platforms do not have expected alignment, and do not use
+  // this code. static_assert would still fire and fail for them.
   static_assert(sizeof(_orig) % HeapWordSize == 0, "align");
+#endif
   Copy::disjoint_words_atomic((HeapWord*) &mdo->_compiler_counters,
                               (HeapWord*) &_orig,
                               sizeof(_orig) / HeapWordSize);

--- a/src/hotspot/share/oops/methodData.hpp
+++ b/src/hotspot/share/oops/methodData.hpp
@@ -1984,7 +1984,11 @@ public:
 
   public:
     CompilerCounters() : _nof_decompiles(0), _nof_overflow_recompiles(0), _nof_overflow_traps(0) {
+#ifndef ZERO
+      // Some Zero platforms do not have expected alignment, and do not use
+      // this code. static_assert would still fire and fail for them.
       static_assert(sizeof(_trap_hist) % HeapWordSize == 0, "align");
+#endif
       uint size_in_words = sizeof(_trap_hist) / HeapWordSize;
       Copy::zero_to_words((HeapWord*) &_trap_hist, size_in_words);
     }


### PR DESCRIPTION
Debian folks report that Zero m68k (and seems only that arch) fails the static assert added by JDK-8252049. It affects at least JDK 16, but would affect more releases once JDK-8252049 is backported.

```
/<<PKGBUILDDIR>>/src/hotspot/share/oops/methodData.hpp: In constructor 'MethodData::CompilerCounters::CompilerCounters()':
/<<PKGBUILDDIR>>/src/hotspot/share/oops/methodData.hpp:1987:55: error: static assertion failed: align
 1987 | static_assert(sizeof(_trap_hist) % HeapWordSize == 0, "align");
      |
```

I tried to massage the code so that `oops/methodData.hpp` is not touched when Zero is built (since Zero does not use compilers and related infra), but there are enough transitive dependencies to `oops/methodData.hpp` to make it quite messy. So instead I would just special-case it in place.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259560](https://bugs.openjdk.java.net/browse/JDK-8259560): Zero m68k: "static assertion failed: align" after JDK-8252049


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/102/head:pull/102`
`$ git checkout pull/102`
