### PR TITLE
8259063: Possible deadlock with vtable/itable creation vs concurrent class unloading

### DIFF
--- a/src/hotspot/share/code/codeBlob.cpp
+++ b/src/hotspot/share/code/codeBlob.cpp
@@ -309,7 +309,7 @@ VtableBlob::VtableBlob(const char* name, int size) :
 }
 
 VtableBlob* VtableBlob::create(const char* name, int buffer_size) {
-  ThreadInVMfromUnknown __tiv;  // get to VM state in case we block on CodeCache_lock
+  assert(JavaThread::current()->thread_state() == _thread_in_vm, "called with the wrong state");
 
   VtableBlob* blob = NULL;
   unsigned int size = sizeof(VtableBlob);
@@ -318,8 +318,21 @@ VtableBlob* VtableBlob::create(const char* name, int buffer_size) {
   size += align_up(buffer_size, oopSize);
   assert(name != NULL, "must provide a name");
   {
-    MutexLocker mu(CodeCache_lock, Mutex::_no_safepoint_check_flag);
+    if (!CodeCache_lock->try_lock()) {
+      // If we can't take the CodeCache_lock, then this is a bad time to perform the ongoing
+      // IC transition to megamorphic, for which this stub will be needed. It is better to
+      // bail out the transition, and wait for a more opportune moment. Not only is it not
+      // worth waiting for the lock blockingly for the megamorphic transition, it might
+      // also result in a deadlock to blockingly wait, when concurrent class unloading is
+      // performed. At this point in time, the CompiledICLocker is taken, so we are not
+      // allowed to blockingly wait for the CodeCache_lock, as these two locks are otherwise
+      // consistently taken in the opposite order. Bailing out results in an IC transition to
+      // the clean state instead, which will cause subsequent calls to retry the transitioning
+      // eventually.
+      return NULL;
+    }
     blob = new (size) VtableBlob(name, size);
+    CodeCache_lock->unlock();
   }
   // Track memory usage statistic after releasing CodeCache_lock
   MemoryService::track_code_cache_memory_usage();

--- a/src/hotspot/share/code/codeBlob.cpp
+++ b/src/hotspot/share/code/codeBlob.cpp
@@ -304,6 +304,16 @@ AdapterBlob* AdapterBlob::create(CodeBuffer* cb) {
   return blob;
 }
 
+void* VtableBlob::operator new(size_t s, unsigned size) throw() {
+  // Handling of allocation failure stops compilation and prints a bunch of
+  // stuff, which requires unlocking the CodeCache_lock, so that the Compile_lock
+  // can be locked, and then re-locking the CodeCache_lock. That is not safe in
+  // this context as we hold the CompiledICLocker. So we just don't handle code
+  // cache exhaustion here; we leave that for a later allocation that does not
+  // hold the CompiledICLocker.
+  return CodeCache::allocate(size, CodeBlobType::NonNMethod, false /* handle_alloc_failure */);
+}
+
 VtableBlob::VtableBlob(const char* name, int size) :
   BufferBlob(name, size) {
 }

--- a/src/hotspot/share/code/codeBlob.hpp
+++ b/src/hotspot/share/code/codeBlob.hpp
@@ -441,6 +441,8 @@ class VtableBlob: public BufferBlob {
 private:
   VtableBlob(const char*, int);
 
+  void* operator new(size_t s, unsigned size) throw();
+
 public:
   // Creation
   static VtableBlob* create(const char* name, int buffer_size);

--- a/src/hotspot/share/code/codeCache.hpp
+++ b/src/hotspot/share/code/codeCache.hpp
@@ -136,7 +136,7 @@ class CodeCache : AllStatic {
   static const GrowableArray<CodeHeap*>* nmethod_heaps() { return _nmethod_heaps; }
 
   // Allocation/administration
-  static CodeBlob* allocate(int size, int code_blob_type, int orig_code_blob_type = CodeBlobType::All); // allocates a new CodeBlob
+  static CodeBlob* allocate(int size, int code_blob_type, bool handle_alloc_failure = true, int orig_code_blob_type = CodeBlobType::All); // allocates a new CodeBlob
   static void commit(CodeBlob* cb);                        // called when the allocated CodeBlob has been filled
   static int  alignment_unit();                            // guaranteed alignment of all CodeBlobs
   static int  alignment_offset();                          // guaranteed offset of first CodeBlob byte within alignment unit (i.e., allocation header)


### PR DESCRIPTION
There is an offender of consistent lock ordering: the creation of itable/vtable stubs. It happens when an inline cache is transitioning to megamorphic. Way earlier in the call stack, we grab the nmethod lock for IC patching, and then when a megamorphic transition happens *and* there is no stub created yet for the given vtable/itable index (rather uncommon), a new vtable/itable stub is created. This creation of a stub takes the CodeCache lock. We already deal with failure to create the stubs today, by making the inline cache "clean" instead, essentially deferring the transition to megamorphic to a subsequent call. We deal with that today to handle the code cache running out of memory, making it temporarily impossible to transition to megamorphic until memory has been freed up. My patch rides on that logic, so that we can try_lock() the CodeCache_lock instead. If we fail to take the lock, then it is arguably a bad time to do this megamorphic transition, regardless of deadlocks, as we might have to wait quite a while. So if we fail to take the lock, I just return NULL saying we couldn't create a vtable/itable stub at this time, signalling we defer the transition to later, as we would also do if we couldn't create the stub due to memory exhaustion. This solves the deadlock situation.

Eric Caspole who reported the bug has tried this patch, and it solved the problem. I also tried it with the same test myself, with the same successful results. I also ran it through tier1-5 as it is touching inline cache code which can be a bit subtle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259063](https://bugs.openjdk.java.net/browse/JDK-8259063): Possible deadlock with vtable/itable creation vs concurrent class unloading


### Reviewers
 * [Per Liden](https://openjdk.java.net/census#pliden) (@pliden - **Reviewer**) ⚠️ Review applies to 71c09794c93c9bfd83502db126267bb0db80efc1
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/103/head:pull/103`
`$ git checkout pull/103`
