### PR TITLE
8259275: JRuby crashes while resolving invokedynamic instruction

### DIFF
--- a/src/hotspot/share/classfile/classListParser.cpp
+++ b/src/hotspot/share/classfile/classListParser.cpp
@@ -474,10 +474,8 @@ void ClassListParser::resolve_indy(Symbol* class_name_symbol, TRAPS) {
       tty->print_cr(" exception pending %s ",
                     PENDING_EXCEPTION->klass()->external_name());
     }
-    Symbol* ex_name = PENDING_EXCEPTION->klass()->name();
     oop exception = THREAD->pending_exception();
-    if (/*ex_name == vmSymbols::java_lang_UnsupportedClassVersionError() ||*/
-        exception->is_a(SystemDictionary::Error_klass())) {
+    if (exception->is_a(SystemDictionary::Error_klass())) {
       CLEAR_PENDING_EXCEPTION;
     } else {
       exit(1);

--- a/src/hotspot/share/classfile/classListParser.cpp
+++ b/src/hotspot/share/classfile/classListParser.cpp
@@ -476,6 +476,8 @@ void ClassListParser::resolve_indy(Symbol* class_name_symbol, TRAPS) {
     }
     oop exception = THREAD->pending_exception();
     if (exception->is_a(SystemDictionary::Error_klass())) {
+      // Clear the exception associated with errors like UnsupportedClassVersionError
+      // or NoSuchMethodError so that CDS dumping can continue.
       CLEAR_PENDING_EXCEPTION;
     } else {
       exit(1);

--- a/src/hotspot/share/classfile/classListParser.cpp
+++ b/src/hotspot/share/classfile/classListParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -460,19 +460,42 @@ bool ClassListParser::is_matching_cp_entry(constantPoolHandle &pool, int cp_inde
   }
   return true;
 }
-
 void ClassListParser::resolve_indy(Symbol* class_name_symbol, TRAPS) {
+  ClassListParser::resolve_indy_impl(class_name_symbol, THREAD);
+  if (HAS_PENDING_EXCEPTION) {
+    ResourceMark rm(THREAD);
+    tty->print("resolve_indy for class %s has", class_name_symbol->as_C_string());
+    oop message = java_lang_Throwable::message(PENDING_EXCEPTION);
+    if (message != NULL) {
+      char* ex_msg = java_lang_String::as_utf8_string(message);
+      tty->print_cr(" exception pending '%s %s'",
+                    PENDING_EXCEPTION->klass()->external_name(), ex_msg);
+    } else {
+      tty->print_cr(" exception pending %s ",
+                    PENDING_EXCEPTION->klass()->external_name());
+    }
+    Symbol* ex_name = PENDING_EXCEPTION->klass()->name();
+    oop exception = THREAD->pending_exception();
+    if (/*ex_name == vmSymbols::java_lang_UnsupportedClassVersionError() ||*/
+        exception->is_a(SystemDictionary::Error_klass())) {
+      CLEAR_PENDING_EXCEPTION;
+    } else {
+      exit(1);
+    }
+  }
+}
+
+void ClassListParser::resolve_indy_impl(Symbol* class_name_symbol, TRAPS) {
   Handle class_loader(THREAD, SystemDictionary::java_system_loader());
   Handle protection_domain;
-  Klass* klass = SystemDictionary::resolve_or_fail(class_name_symbol, class_loader, protection_domain, true, THREAD); // FIXME should really be just a lookup
+  Klass* klass = SystemDictionary::resolve_or_fail(class_name_symbol, class_loader, protection_domain, true, CHECK); // FIXME should really be just a lookup
   if (klass != NULL && klass->is_instance_klass()) {
     InstanceKlass* ik = InstanceKlass::cast(klass);
     if (SystemDictionaryShared::has_class_failed_verification(ik)) {
       // don't attempt to resolve indy on classes that has previously failed verification
       return;
     }
-    MetaspaceShared::try_link_class(ik, THREAD);
-    assert(!HAS_PENDING_EXCEPTION, "unexpected exception");
+    MetaspaceShared::try_link_class(ik, CHECK);
 
     ConstantPool* cp = ik->constants();
     ConstantPoolCache* cpcache = cp->cache();
@@ -484,36 +507,23 @@ void ClassListParser::resolve_indy(Symbol* class_name_symbol, TRAPS) {
       constantPoolHandle pool(THREAD, cp);
       if (pool->tag_at(pool_index).is_invoke_dynamic()) {
         BootstrapInfo bootstrap_specifier(pool, pool_index, indy_index);
-        Handle bsm = bootstrap_specifier.resolve_bsm(THREAD);
+        Handle bsm = bootstrap_specifier.resolve_bsm(CHECK);
         if (!SystemDictionaryShared::is_supported_invokedynamic(&bootstrap_specifier)) {
           log_debug(cds, lambda)("is_supported_invokedynamic check failed for cp_index %d", pool_index);
           continue;
         }
-        if (is_matching_cp_entry(pool, pool_index, THREAD)) {
+        bool matched = is_matching_cp_entry(pool, pool_index, CHECK);
+        if (matched) {
           found = true;
           CallInfo info;
-          bool is_done = bootstrap_specifier.resolve_previously_linked_invokedynamic(info, THREAD);
+          bool is_done = bootstrap_specifier.resolve_previously_linked_invokedynamic(info, CHECK);
           if (!is_done) {
             // resolve it
             Handle recv;
-            LinkResolver::resolve_invoke(info, recv, pool, indy_index, Bytecodes::_invokedynamic, THREAD);
+            LinkResolver::resolve_invoke(info, recv, pool, indy_index, Bytecodes::_invokedynamic, CHECK);
             break;
           }
           cpce->set_dynamic_call(pool, info);
-          if (HAS_PENDING_EXCEPTION) {
-            ResourceMark rm(THREAD);
-            tty->print("resolve_indy for class %s has", class_name_symbol->as_C_string());
-            oop message = java_lang_Throwable::message(PENDING_EXCEPTION);
-            if (message != NULL) {
-              char* ex_msg = java_lang_String::as_utf8_string(message);
-              tty->print_cr(" exception pending '%s %s'",
-                         PENDING_EXCEPTION->klass()->external_name(), ex_msg);
-            } else {
-              tty->print_cr(" exception pending %s ",
-                         PENDING_EXCEPTION->klass()->external_name());
-            }
-            exit(1);
-          }
         }
       }
     }

--- a/src/hotspot/share/classfile/classListParser.cpp
+++ b/src/hotspot/share/classfile/classListParser.cpp
@@ -37,6 +37,7 @@
 #include "interpreter/bytecodeStream.hpp"
 #include "interpreter/linkResolver.hpp"
 #include "logging/log.hpp"
+#include "logging/logStream.hpp"
 #include "logging/logTag.hpp"
 #include "memory/archiveUtils.hpp"
 #include "memory/metaspaceShared.hpp"
@@ -463,19 +464,23 @@ bool ClassListParser::is_matching_cp_entry(constantPoolHandle &pool, int cp_inde
 void ClassListParser::resolve_indy(Symbol* class_name_symbol, TRAPS) {
   ClassListParser::resolve_indy_impl(class_name_symbol, THREAD);
   if (HAS_PENDING_EXCEPTION) {
-    ResourceMark rm(THREAD);
-    tty->print("resolve_indy for class %s has", class_name_symbol->as_C_string());
-    oop message = java_lang_Throwable::message(PENDING_EXCEPTION);
-    if (message != NULL) {
-      char* ex_msg = java_lang_String::as_utf8_string(message);
-      tty->print_cr(" exception pending '%s %s'",
-                    PENDING_EXCEPTION->klass()->external_name(), ex_msg);
-    } else {
-      tty->print_cr(" exception pending %s ",
-                    PENDING_EXCEPTION->klass()->external_name());
+    LogTarget(Debug, cds, lambda) log;
+    if (log.is_enabled()) {
+      ResourceMark rm(THREAD);
+      LogStream ls(log);
+      log.print("resolve_indy for class %s has", class_name_symbol->as_C_string());
+      oop message = java_lang_Throwable::message(PENDING_EXCEPTION);
+      if (message != NULL) {
+        char* ex_msg = java_lang_String::as_utf8_string(message);
+        ls.print(" exception pending '%s %s'",
+                  PENDING_EXCEPTION->klass()->external_name(), ex_msg);
+      } else {
+        ls.print(" exception pending %s ",
+                  PENDING_EXCEPTION->klass()->external_name());
+      }
     }
     oop exception = THREAD->pending_exception();
-    if (exception->is_a(SystemDictionary::Error_klass())) {
+    if (exception->is_a(SystemDictionary::LinkageError_klass())) {
       // Clear the exception associated with errors like UnsupportedClassVersionError
       // or NoSuchMethodError so that CDS dumping can continue.
       CLEAR_PENDING_EXCEPTION;

--- a/src/hotspot/share/classfile/classListParser.hpp
+++ b/src/hotspot/share/classfile/classListParser.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -114,6 +114,7 @@ class ClassListParser : public StackObj {
   bool is_matching_cp_entry(constantPoolHandle &pool, int cp_index, TRAPS);
 
   void resolve_indy(Symbol* class_name_symbol, TRAPS);
+  void resolve_indy_impl(Symbol* class_name_symbol, TRAPS);
 public:
   ClassListParser(const char* file);
   ~ClassListParser();

--- a/src/hotspot/share/oops/constantPool.cpp
+++ b/src/hotspot/share/oops/constantPool.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -406,15 +406,14 @@ void ConstantPool::remove_unshareable_info() {
   _flags |= (_on_stack | _is_shared);
   int num_klasses = 0;
   for (int index = 1; index < length(); index++) { // Index 0 is unused
-    if (!DynamicDumpSharedSpaces) {
-      assert(!tag_at(index).is_unresolved_klass_in_error(), "This must not happen during static dump time");
-    } else {
-      if (tag_at(index).is_unresolved_klass_in_error() ||
-          tag_at(index).is_method_handle_in_error()    ||
-          tag_at(index).is_method_type_in_error()      ||
-          tag_at(index).is_dynamic_constant_in_error()) {
-        tag_at_put(index, JVM_CONSTANT_UnresolvedClass);
-      }
+    if (tag_at(index).is_unresolved_klass_in_error()) {
+      tag_at_put(index, JVM_CONSTANT_UnresolvedClass);
+    } else if (tag_at(index).is_method_handle_in_error()) {
+      tag_at_put(index, JVM_CONSTANT_MethodHandle);
+    } else if (tag_at(index).is_method_type_in_error()) {
+      tag_at_put(index, JVM_CONSTANT_MethodType);
+    } else if (tag_at(index).is_dynamic_constant_in_error()) {
+      tag_at_put(index, JVM_CONSTANT_Dynamic);
     }
     if (tag_at(index).is_klass()) {
       // This class was resolved as a side effect of executing Java code

--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -336,6 +336,7 @@ hotspot_appcds_dynamic = \
  -runtime/cds/appcds/LambdaEagerInit.java \
  -runtime/cds/appcds/LambdaProxyClasslist.java \
  -runtime/cds/appcds/LambdaVerificationFailedDuringDump.java \
+ -runtime/cds/appcds/LambdaWithOldClass.java \
  -runtime/cds/appcds/LongClassListPath.java \
  -runtime/cds/appcds/LotsOfClasses.java \
  -runtime/cds/appcds/NonExistClasspath.java \

--- a/test/hotspot/jtreg/runtime/cds/appcds/BadBSM.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/BadBSM.java
@@ -45,7 +45,6 @@ public class BadBSM {
                         "@lambda-proxy WrongBSM 7"),
         "-Xlog:cds+lambda=debug");
     out.shouldHaveExitValue(0)
-       .shouldContain("resolve_indy for class WrongBSM has")
-       .shouldContain("exception pending 'java.lang.NoSuchMethodError '");
+       .shouldContain("resolve_indy for class WrongBSM has encountered exception: java.lang.NoSuchMethodError");
   }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/BadBSM.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/BadBSM.java
@@ -45,6 +45,7 @@ public class BadBSM {
                         "@lambda-proxy WrongBSM 7"),
         "-Xlog:cds+lambda=debug");
     out.shouldHaveExitValue(0)
-       .shouldContain("resolve_indy for class WrongBSM has exception pending 'java.lang.NoSuchMethodError '");
+       .shouldContain("resolve_indy for class WrongBSM has")
+       .shouldContain("exception pending 'java.lang.NoSuchMethodError '");
   }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/LambdaWithOldClass.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/LambdaWithOldClass.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @bug 8259275
+ * @summary VM should not crash during CDS dump and run time when a lambda
+ *          expression references an old version of class.
+ * @requires vm.cds
+ * @library /test/lib
+ * @compile test-classes/OldClass.jasm
+ * @compile test-classes/LambdaWithOldClassApp.java
+ * @run driver LambdaWithOldClass
+ */
+
+import jdk.test.lib.cds.CDSOptions;
+import jdk.test.lib.cds.CDSTestUtils;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class LambdaWithOldClass {
+
+    public static void main(String[] args) throws Exception {
+        String mainClass = "LambdaWithOldClassApp";
+        String namePrefix = "lambdawitholdclass";
+        JarBuilder.build(namePrefix, mainClass, "OldClass", "TestInterface");
+
+        String appJar = TestCommon.getTestJar(namePrefix + ".jar");
+        String classList = namePrefix + ".list";
+        String archiveName = namePrefix + ".jsa";
+
+        // dump class list
+        ProcessBuilder pb = ProcessTools.createTestJvm(
+            "-XX:DumpLoadedClassList=" + classList,
+            "-cp", appJar,
+            mainClass);
+        OutputAnalyzer output = TestCommon.executeAndLog(pb, namePrefix);
+        output.shouldHaveExitValue(0);
+
+        // create archive with the class list
+        CDSOptions opts = (new CDSOptions())
+            .addPrefix("-XX:ExtraSharedClassListFile=" + classList,
+                       "-cp", appJar,
+                       "-Xlog:class+load,cds")
+            .setArchiveName(archiveName);
+        CDSTestUtils.createArchiveAndCheck(opts);
+
+        // run with archive
+        CDSOptions runOpts = (new CDSOptions())
+            .addPrefix("-cp", appJar, "-Xlog:class+load,cds=debug")
+            .setArchiveName(archiveName)
+            .setUseVersion(false)
+            .addSuffix(mainClass);
+        output = CDSTestUtils.runWithArchive(runOpts);
+        output.shouldContain("[class,load] LambdaWithOldClassApp source: shared objects file")
+              .shouldMatch(".class.load. LambdaWithOldClassApp[$][$]Lambda[$].*/0x.*source:.*LambdaWithOldClassApp")
+              .shouldHaveExitValue(0);
+    }
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/test-classes/LambdaWithOldClassApp.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/test-classes/LambdaWithOldClassApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,30 +21,18 @@
  * questions.
  *
  */
+interface TestInterface {
+    public void apply(OldClass c);
+}
 
-/*
- * @test
- * @summary CDS dump should abort if a class file contains a bad BSM.
- * @requires vm.cds
- * @library /test/lib
- * @compile test-classes/WrongBSM.jcod
- * @run driver BadBSM
- */
-
-import jdk.test.lib.process.OutputAnalyzer;
-
-public class BadBSM {
-
-  public static void main(String[] args) throws Exception {
-    JarBuilder.build("wrongbsm", "WrongBSM");
-
-    String appJar = TestCommon.getTestJar("wrongbsm.jar");
-
-    OutputAnalyzer out = TestCommon.dump(appJar,
-        TestCommon.list("WrongBSM",
-                        "@lambda-proxy WrongBSM 7"),
-        "-Xlog:cds+lambda=debug");
-    out.shouldHaveExitValue(0)
-       .shouldContain("resolve_indy for class WrongBSM has exception pending 'java.lang.NoSuchMethodError '");
-  }
+public class LambdaWithOldClassApp {
+    public static void main(String args[]) {
+        doit((c) -> {
+                System.out.println("c = " + c);
+            });
+    }
+    static void doit(TestInterface i) {
+        OldClass c = new OldClass();
+        i.apply(c);
+    }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/test-classes/OldClass.jasm
+++ b/test/hotspot/jtreg/runtime/cds/appcds/test-classes/OldClass.jasm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,30 +21,17 @@
  * questions.
  *
  */
+super class OldClass
+	version 49:0
+{
 
-/*
- * @test
- * @summary CDS dump should abort if a class file contains a bad BSM.
- * @requires vm.cds
- * @library /test/lib
- * @compile test-classes/WrongBSM.jcod
- * @run driver BadBSM
- */
 
-import jdk.test.lib.process.OutputAnalyzer;
-
-public class BadBSM {
-
-  public static void main(String[] args) throws Exception {
-    JarBuilder.build("wrongbsm", "WrongBSM");
-
-    String appJar = TestCommon.getTestJar("wrongbsm.jar");
-
-    OutputAnalyzer out = TestCommon.dump(appJar,
-        TestCommon.list("WrongBSM",
-                        "@lambda-proxy WrongBSM 7"),
-        "-Xlog:cds+lambda=debug");
-    out.shouldHaveExitValue(0)
-       .shouldContain("resolve_indy for class WrongBSM has exception pending 'java.lang.NoSuchMethodError '");
-  }
+Method "<init>":"()V"
+	stack 1 locals 1
+{
+		aload_0;
+		invokespecial	Method java/lang/Object."<init>":"()V";
+		return;
 }
+
+} // end Class OldClass


### PR DESCRIPTION
Please review this proposed change which fixes 2 problems during CDS dump time:

- in `ClassListParser::resolve_indy()`, exception could be thrown from `bootstrap_specifier.resolve_bsm()` but was not handled;
- in `ConstantPool::remove_unshareable_info()`, tag was not setup correctly on error conditions.

Passed tiers 1 - 4 testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259275](https://bugs.openjdk.java.net/browse/JDK-8259275): JRuby crashes while resolving invokedynamic instruction


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)
 * [Yumin Qi](https://openjdk.java.net/census#minqi) (@yminqi - **Reviewer**) ⚠️ Review applies to 6786de937f2ac820ca04dfe895c9139532504e9d
 * [Lois Foltan](https://openjdk.java.net/census#lfoltan) (@lfoltan - **Reviewer**) ⚠️ Review applies to e139e9646dd10bb268334c8a5c9f99725aa5f63c


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/104/head:pull/104`
`$ git checkout pull/104`
