### PR TITLE
8258272: LoadVectorMaskedNode can't be replaced by zero con

### DIFF
--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -2045,7 +2045,7 @@ const Type* LoadNode::Value(PhaseGVN* phase) const {
     }
   }
 
-  if (is_instance && !_type->is_vect()) {
+  if (is_instance && (_type->isa_vect() == NULL)) {
     // If we have an instance type and our memory input is the
     // programs's initial memory state, there is no matching store,
     // so just return a zero of the appropriate type -

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -2045,7 +2045,8 @@ const Type* LoadNode::Value(PhaseGVN* phase) const {
     }
   }
 
-  if (is_instance && (_type->isa_vect() == NULL)) {
+  bool is_vect = (_type->isa_vect() != NULL);
+  if (is_instance && !is_vect) {
     // If we have an instance type and our memory input is the
     // programs's initial memory state, there is no matching store,
     // so just return a zero of the appropriate type -

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -2045,10 +2045,11 @@ const Type* LoadNode::Value(PhaseGVN* phase) const {
     }
   }
 
-  if (is_instance) {
+  if (is_instance && !_type->is_vect()) {
     // If we have an instance type and our memory input is the
     // programs's initial memory state, there is no matching store,
-    // so just return a zero of the appropriate type
+    // so just return a zero of the appropriate type -
+    // except if it is vectorized - then we have no zero constant.
     Node *mem = in(MemNode::Memory);
     if (mem->is_Parm() && mem->in(0)->is_Start()) {
       assert(mem->as_Parm()->_con == TypeFunc::Memory, "must be memory Parm");

--- a/test/hotspot/jtreg/compiler/arraycopy/TestArrayCopyMaskedWithZeroSrc.java
+++ b/test/hotspot/jtreg/compiler/arraycopy/TestArrayCopyMaskedWithZeroSrc.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8258272
+ * @summary Test that LoadVectorMaskedNodes works when the source array is known to only contain zeros
+ *
+ * @run main/othervm -XX:-BackgroundCompilation -XX:CompileCommand=dontinline,*::testArrayCopy*
+ *                   compiler.arraycopy.TestArrayCopyMaskedWithZeroSrc
+ */
+
+package compiler.arraycopy;
+
+import java.util.*;
+
+public class TestArrayCopyMaskedWithZeroSrc {
+
+    public static void main(String[] args) {
+        TestArrayCopyMaskedWithZeroSrc t = new TestArrayCopyMaskedWithZeroSrc();
+        t.test();
+    }
+
+    void test() {
+        for (int i = 0; i < 20000; i++) {
+            testArrayCopy1(3);
+        }
+    }
+
+    // src is allocated locally - it is known it only contains zeros.
+    // The copy of will exapnd into LoadVectorMasked on AVX512 machines
+    // LoadNode::value will try to replace the load from src with a zero constant.
+
+    byte [] testArrayCopy1(int partial_len) {
+        byte [] src = new byte[5];
+        byte [] dest = Arrays.copyOf(src, partial_len);
+        return dest;
+    }
+}


### PR DESCRIPTION
A test fails for this code:

byte [] src = new byte[0];
byte [] dest = Arrays::copy_of(src);

This is transformed to something like:
byte [] src = new byte[0];
byte [] dest = new byte[0];
System.arraycopy(src, 0, dest, 0, src.lenght());

This causes a problem in LoadNode::Value for the new LoadVectorMasked nodes. LoadNode::Value sees that the load will always load a zero - and will try to replace itself with a zero constant. That doesn't work for the LoadVectorMaskedNodes currently.

This patch adds a check to the zero-optimization to pass on vector types.

This patch is currently missing a new test. Since we are nearing the end of bugfixing in JDK16 I decided to publish the fix first so that any discussion of the fix can be had now.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258272](https://bugs.openjdk.java.net/browse/JDK-8258272): LoadVectorMaskedNode can't be replaced by zero con


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/105/head:pull/105`
`$ git checkout pull/105`
