### PR TITLE
8259601: AArch64: Fix reinterpretX2D match rule issue

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64_neon.ad
+++ b/src/hotspot/cpu/aarch64/aarch64_neon.ad
@@ -1,5 +1,5 @@
-// Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
-// Copyright (c) 2020, Arm Limited. All rights reserved.
+// Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+// Copyright (c) 2020, 2021, Arm Limited. All rights reserved.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
 // This code is free software; you can redistribute it and/or modify it
@@ -84,9 +84,11 @@ instruct reinterpretD2X(vecX dst, vecD src)
             n->in(1)->bottom_type()->is_vect()->length_in_bytes() == 8);
   match(Set dst (VectorReinterpret src));
   ins_cost(INSN_COST);
-  format %{ " # reinterpret $dst,$src" %}
+  format %{ " # reinterpret $dst,$src\t# D2X" %}
   ins_encode %{
-    // If register is the same, then move is not needed.
+    // If registers are the same, no register move is required - the
+    // upper 64 bits of 'src' are expected to have been initialized
+    // to zero.
     if (as_FloatRegister($dst$$reg) != as_FloatRegister($src$$reg)) {
       __ orr(as_FloatRegister($dst$$reg), __ T8B,
              as_FloatRegister($src$$reg),
@@ -102,14 +104,13 @@ instruct reinterpretX2D(vecD dst, vecX src)
             n->in(1)->bottom_type()->is_vect()->length_in_bytes() == 16);
   match(Set dst (VectorReinterpret src));
   ins_cost(INSN_COST);
-  format %{ " # reinterpret $dst,$src" %}
+  format %{ " # reinterpret $dst,$src\t# X2D" %}
   ins_encode %{
-    // If register is the same, then move is not needed.
-    if (as_FloatRegister($dst$$reg) != as_FloatRegister($src$$reg)) {
-      __ orr(as_FloatRegister($dst$$reg), __ T8B,
-             as_FloatRegister($src$$reg),
-             as_FloatRegister($src$$reg));
-    }
+    // Resize the vector from 128-bits to 64-bits. The higher 64-bits of
+    // the "dst" register must be cleared to zero.
+    __ orr(as_FloatRegister($dst$$reg), __ T8B,
+           as_FloatRegister($src$$reg),
+           as_FloatRegister($src$$reg));
   %}
   ins_pipe(vlogical64);
 %}

--- a/src/hotspot/cpu/aarch64/aarch64_neon_ad.m4
+++ b/src/hotspot/cpu/aarch64/aarch64_neon_ad.m4
@@ -1,5 +1,5 @@
-// Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
-// Copyright (c) 2020, Arm Limited. All rights reserved.
+// Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+// Copyright (c) 2020, 2021, Arm Limited. All rights reserved.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
 // This code is free software; you can redistribute it and/or modify it
@@ -97,16 +97,18 @@ dnl         $1 $2
 REINTERPRET(D, 8)
 REINTERPRET(X, 16)
 dnl
-define(`REINTERPRET_X', `
-instruct reinterpret$1`'2$2`'(vec$2 dst, vec$1 src)
+
+instruct reinterpretD2X(vecX dst, vecD src)
 %{
-  predicate(n->bottom_type()->is_vect()->length_in_bytes() == $3 &&
-            n->in(1)->bottom_type()->is_vect()->length_in_bytes() == $4);
+  predicate(n->bottom_type()->is_vect()->length_in_bytes() == 16 &&
+            n->in(1)->bottom_type()->is_vect()->length_in_bytes() == 8);
   match(Set dst (VectorReinterpret src));
   ins_cost(INSN_COST);
-  format %{ " # reinterpret $dst,$src" %}
+  format %{ " # reinterpret $dst,$src\t# D2X" %}
   ins_encode %{
-    // If register is the same, then move is not needed.
+    // If registers are the same, no register move is required - the
+    // upper 64 bits of 'src' are expected to have been initialized
+    // to zero.
     if (as_FloatRegister($dst$$reg) != as_FloatRegister($src$$reg)) {
       __ orr(as_FloatRegister($dst$$reg), __ T8B,
              as_FloatRegister($src$$reg),
@@ -114,11 +116,24 @@ instruct reinterpret$1`'2$2`'(vec$2 dst, vec$1 src)
     }
   %}
   ins_pipe(vlogical64);
-%}')dnl
-dnl           $1 $2 $3  $4
-REINTERPRET_X(D, X, 16, 8)
-REINTERPRET_X(X, D, 8,  16)
-dnl
+%}
+
+instruct reinterpretX2D(vecD dst, vecX src)
+%{
+  predicate(n->bottom_type()->is_vect()->length_in_bytes() == 8 &&
+            n->in(1)->bottom_type()->is_vect()->length_in_bytes() == 16);
+  match(Set dst (VectorReinterpret src));
+  ins_cost(INSN_COST);
+  format %{ " # reinterpret $dst,$src\t# X2D" %}
+  ins_encode %{
+    // Resize the vector from 128-bits to 64-bits. The higher 64-bits of
+    // the "dst" register must be cleared to zero.
+    __ orr(as_FloatRegister($dst$$reg), __ T8B,
+           as_FloatRegister($src$$reg),
+           as_FloatRegister($src$$reg));
+  %}
+  ins_pipe(vlogical64);
+%}
 
 // ------------------------------ Vector cast -------------------------------
 dnl


### PR DESCRIPTION
Currently the `"reinterpretX2D"` match rule does not generate any register move instruction if the` 'dst'` and` 'src'` are the same register. This rule implements the vector reinterpretation from 16 bytes to 8 bytes. It is a kind of data truncation, which should make sure the higher 8 bytes of the `'dst' `register cleared to zero. So the `"mov" `is always needed even if the` "dst"` and `"src"` are the same register in case of the issue mentioned in [1].

We have tested the case [3] with Arm NEON. And the issue still exists even if [1] is fixed with [2]. Removing the check (i.e. whether `'src'` and `'dst`' are the same register) in the rule would fix it finally.

[1] https://bugs.openjdk.java.net/browse/JDK-8259353
[2] https://github.com/openjdk/jdk16/pull/100
[3] https://bugs.openjdk.java.net/secure/attachment/92713/Test.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259601](https://bugs.openjdk.java.net/browse/JDK-8259601): AArch64: Fix reinterpretX2D match rule issue


### Reviewers
 * [Andrew Dinn](https://openjdk.java.net/census#adinn) (@adinn - **Reviewer**)
 * [Ningsheng Jian](https://openjdk.java.net/census#njian) (@nsjian - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/108/head:pull/108`
`$ git checkout pull/108`
