### PR TITLE
8259634: MemorySegment::asByteBuffer does not respect spatial bounds

### DIFF
--- a/src/java.base/share/classes/java/nio/Buffer.java
+++ b/src/java.base/share/classes/java/nio/Buffer.java
@@ -793,7 +793,7 @@ public abstract class Buffer {
 
                 @Override
                 public ByteBuffer newHeapByteBuffer(byte[] hb, int offset, int capacity, MemorySegmentProxy segment) {
-                    return new HeapByteBuffer(hb, offset, capacity, segment);
+                    return new HeapByteBuffer(hb, -1, 0, capacity, capacity, offset, segment);
                 }
 
                 @Override


### PR DESCRIPTION
The byte buffers created from heap segments do not honor the javadoc - which says that the resulting buffer size should be equal to MemorySegment::byteSize, and that the buffer position should be zero.

The issue is that the NIO routine we have added to create heap buffers is using the wrong constructor, which doesn't do what we need. The fix is to simply use the proper, more complete constructor.

I've also re-enabled an unrelated test which was missing the @Test annotation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259634](https://bugs.openjdk.java.net/browse/JDK-8259634): MemorySegment::asByteBuffer does not respect spatial bounds


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/109/head:pull/109`
`$ git checkout pull/109`
