### PR TITLE
8259636: Check for buffer backed by shared segment kicks in in unexpected places

### DIFF
--- a/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
@@ -203,7 +203,7 @@ class Direct$Type$Buffer$RW$$BO$
     {
 #if[rw]
         super(mark, pos, lim, cap, segment);
-        address = db.address() + off;
+        address = ((Buffer)db).address + off;
 #if[byte]
         cleaner = null;
 #end[byte]

--- a/test/jdk/java/foreign/TestByteBuffer.java
+++ b/test/jdk/java/foreign/TestByteBuffer.java
@@ -71,6 +71,7 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import jdk.internal.foreign.HeapMemorySegmentImpl;
@@ -646,6 +647,23 @@ public class TestByteBuffer {
             ByteBuffer bb = segment.asByteBuffer();
             channel.write(bb);
         }
+    }
+
+    @Test(dataProvider="segments")
+    public void viewsFromSharedSegment(Supplier<MemorySegment> segmentSupplier) {
+        try (MemorySegment segment = segmentSupplier.get().share()) {
+            var byteBuffer = segment.asByteBuffer();
+            byteBuffer.asReadOnlyBuffer();
+            byteBuffer.slice(0, 8);
+        }
+    }
+
+    @DataProvider(name = "segments")
+    public static Object[][] segments() throws Throwable {
+        return new Object[][] {
+                { (Supplier<MemorySegment>) () -> MemorySegment.allocateNative(16) },
+                { (Supplier<MemorySegment>) () -> MemorySegment.ofArray(new byte[16]) }
+        };
     }
 
     @DataProvider(name = "bufferOps")


### PR DESCRIPTION
When support for shared segment was added, we decided to disable support for buffers derived from shared segment in certain async operations, as there's currently no way to make sure that the memory won't be reclaimed while the IO operation is still taking place.

After looking at the code, it seemed like the best place to put the restriction would be sun.nio.ch.DirectBuffer::address() method, since this method is used in a lot of places just before jumping into some piece of JNI code.

While I still stand by that decision, the Netty team has discovered that this decision also affected operations such as creating slices from byte buffers derived from shared segment - this is caused by the fact that one direct buffer constructor (the one for views and slices) is calling the dreaded DirectBuffer::address method.

The fix is simple: just avoid the method call - which is very easy to do in the case of the buffer constructor: in fact this method just returns the value of the `address` field inside the `Buffer` class, so we can always cast to `Buffer` and then access `address` field from there.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259636](https://bugs.openjdk.java.net/browse/JDK-8259636): Check for buffer backed by shared segment kicks in in unexpected places


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - **Reviewer**) ⚠️ Review applies to b64ff261e1a7fac28045b1f5d9c9f20fd533a1a9
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to b64ff261e1a7fac28045b1f5d9c9f20fd533a1a9
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**) ⚠️ Review applies to b64ff261e1a7fac28045b1f5d9c9f20fd533a1a9


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/110/head:pull/110`
`$ git checkout pull/110`
