### PR TITLE
8253505: JFR: onFlush invoked out of order with a sorted event stream

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordingFile.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordingFile.java
@@ -103,6 +103,9 @@ public final class RecordingFile implements Closeable {
         isLastEventInChunk = false;
         RecordedEvent event = nextEvent;
         nextEvent = chunkParser.readEvent();
+        while (nextEvent == ChunkParser.FLUSH_MARKER) {
+            nextEvent = chunkParser.readEvent();
+        }
         if (nextEvent == null) {
             isLastEventInChunk = true;
             findNext();
@@ -251,6 +254,9 @@ public final class RecordingFile implements Closeable {
                 return;
             }
             nextEvent = chunkParser.readEvent();
+            while (nextEvent == ChunkParser.FLUSH_MARKER) {
+                nextEvent = chunkParser.readEvent();
+            }
         }
     }
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/AbstractEventStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/AbstractEventStream.java
@@ -233,6 +233,14 @@ public abstract class AbstractEventStream implements EventStream {
         return flushOperation;
     }
 
+
+    final protected void onFlush() {
+       Runnable r = getFlushOperation();
+       if (r != null) {
+           r.run();
+       }
+    }
+
     private void startInternal(long startNanos) {
         synchronized (streamConfiguration) {
             if (streamConfiguration.started) {
@@ -291,7 +299,7 @@ public abstract class AbstractEventStream implements EventStream {
         streamConfiguration.addMetadataAction(action);
     }
 
-    protected final void emitMetadataEvent(ChunkParser parser) {
+    protected final void onMetadata(ChunkParser parser) {
         if (parser.hasStaleMetadata()) {
             if (dispatcher.hasMetadataHandler()) {
                 List<EventType> ce = parser.getEventTypes();

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/Dispatcher.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/Dispatcher.java
@@ -38,8 +38,6 @@ import jdk.jfr.internal.consumer.ChunkParser.ParserConfiguration;
 
 final class Dispatcher {
 
-    public final static RecordedEvent FLUSH_MARKER = JdkJfrConsumer.instance().newRecordedEvent(null, null, 0L, 0L);
-
     final static class EventDispatcher {
         private final static EventDispatcher[] NO_DISPATCHERS = new EventDispatcher[0];
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/EventDirectoryStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/EventDirectoryStream.java
@@ -241,11 +241,11 @@ public class EventDirectoryStream extends AbstractEventStream {
         while (true) {
             RecordedEvent e = currentParser.readStreamingEvent();
             if (e == null) {
-                onMetadata(currentParser);
+                onFlush();
                 return true;
-            } else {
-                c.dispatch(e);
             }
+            onMetadata(currentParser);
+            c.dispatch(e);
         }
     }
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/EventDirectoryStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/EventDirectoryStream.java
@@ -143,7 +143,7 @@ public class EventDirectoryStream extends AbstractEventStream {
             long filterEnd = disp.endTime != null ? disp.endNanos : Long.MAX_VALUE;
 
             while (!isClosed()) {
-                emitMetadataEvent(currentParser);
+                onMetadata(currentParser);
                 while (!isClosed() && !currentParser.isChunkFinished()) {
                     disp = dispatcher();
                     if (disp != lastDisp) {
@@ -151,7 +151,6 @@ public class EventDirectoryStream extends AbstractEventStream {
                         pc.filterStart = filterStart;
                         pc.filterEnd = filterEnd;
                         currentParser.updateConfiguration(pc, true);
-                        currentParser.setFlushOperation(getFlushOperation());
                         lastDisp = disp;
                     }
                     if (disp.parserConfiguration.isOrdered()) {
@@ -221,9 +220,10 @@ public class EventDirectoryStream extends AbstractEventStream {
             }
             sortedCache[index++] = e;
         }
-        emitMetadataEvent(currentParser);
+        onMetadata(currentParser);
         // no events found
         if (index == 0 && currentParser.isChunkFinished()) {
+            onFlush();
             return;
         }
         // at least 2 events, sort them
@@ -233,6 +233,7 @@ public class EventDirectoryStream extends AbstractEventStream {
         for (int i = 0; i < index; i++) {
             c.dispatch(sortedCache[i]);
         }
+        onFlush();
         return;
     }
 
@@ -240,7 +241,7 @@ public class EventDirectoryStream extends AbstractEventStream {
         while (true) {
             RecordedEvent e = currentParser.readStreamingEvent();
             if (e == null) {
-                emitMetadataEvent(currentParser);
+                onMetadata(currentParser);
                 return true;
             } else {
                 c.dispatch(e);

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/EventFileStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/EventFileStream.java
@@ -28,6 +28,7 @@ package jdk.jfr.internal.consumer;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.security.AccessControlContext;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
@@ -87,7 +88,7 @@ public final class EventFileStream extends AbstractEventStream {
 
         currentParser = new ChunkParser(input, disp.parserConfiguration);
         while (!isClosed()) {
-            emitMetadataEvent(currentParser);
+            onMetadata(currentParser);
             if (currentParser.getStartNanos() > end) {
                 close();
                 return;
@@ -96,7 +97,6 @@ public final class EventFileStream extends AbstractEventStream {
             disp.parserConfiguration.filterStart = start;
             disp.parserConfiguration.filterEnd = end;
             currentParser.updateConfiguration(disp.parserConfiguration, true);
-            currentParser.setFlushOperation(getFlushOperation());
             if (disp.parserConfiguration.isOrdered()) {
                 processOrdered(disp);
             } else {
@@ -116,46 +116,42 @@ public final class EventFileStream extends AbstractEventStream {
         }
         RecordedEvent event;
         int index = 0;
-        while (true) {
-            event = currentParser.readEvent();
-            if (event == Dispatcher.FLUSH_MARKER) {
-                emitMetadataEvent(currentParser);
-                dispatchOrdered(c, index);
-                index = 0;
-                continue;
+        while (!currentParser.isChunkFinished()) {
+            while ((event = currentParser.readStreamingEvent()) != null) {
+                if (index == cacheSorted.length) {
+                    RecordedEvent[] tmp = cacheSorted;
+                    cacheSorted = new RecordedEvent[2 * tmp.length];
+                    System.arraycopy(tmp, 0, cacheSorted, 0, tmp.length);
+                }
+                cacheSorted[index++] = event;
             }
-
-            if (event == null) {
-                emitMetadataEvent(currentParser);
-                dispatchOrdered(c, index);
-                return;
-            }
-            if (index == cacheSorted.length) {
-                RecordedEvent[] tmp = cacheSorted;
-                cacheSorted = new RecordedEvent[2 * tmp.length];
-                System.arraycopy(tmp, 0, cacheSorted, 0, tmp.length);
-            }
-            cacheSorted[index++] = event;
+            dispatchOrdered(c, index);
+            onFlush();
         }
     }
 
     private void dispatchOrdered(Dispatcher c, int index) {
+        onMetadata(currentParser);
         Arrays.sort(cacheSorted, 0, index, EVENT_COMPARATOR);
         for (int i = 0; i < index; i++) {
             c.dispatch(cacheSorted[i]);
         }
+        onFlush();
     }
 
     private void processUnordered(Dispatcher c) throws IOException {
+        onMetadata(currentParser);
         while (!isClosed()) {
-            RecordedEvent event = currentParser.readEvent();
+            RecordedEvent event = currentParser.readStreamingEvent();
             if (event == null) {
-                emitMetadataEvent(currentParser);
-                return;
+                onFlush();
+                if (currentParser.isChunkFinished()) {
+                    return;
+                }
+                continue;
             }
-            if (event != Dispatcher.FLUSH_MARKER) {
-                c.dispatch(event);
-            }
+            onMetadata(currentParser);
+            c.dispatch(event);
         }
     }
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/EventFileStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/EventFileStream.java
@@ -116,7 +116,6 @@ public final class EventFileStream extends AbstractEventStream {
         }
         RecordedEvent event;
         int index = 0;
-        onMetadata(currentParser); // if events are missing in chunk
         while (!currentParser.isChunkFinished()) {
             while ((event = currentParser.readStreamingEvent()) != null) {
                 if (index == cacheSorted.length) {
@@ -127,6 +126,7 @@ public final class EventFileStream extends AbstractEventStream {
                 cacheSorted[index++] = event;
             }
             dispatchOrdered(c, index);
+            index = 0;
         }
     }
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/EventFileStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/EventFileStream.java
@@ -116,6 +116,7 @@ public final class EventFileStream extends AbstractEventStream {
         }
         RecordedEvent event;
         int index = 0;
+        onMetadata(currentParser); // if events are missing in chunk
         while (!currentParser.isChunkFinished()) {
             while ((event = currentParser.readStreamingEvent()) != null) {
                 if (index == cacheSorted.length) {
@@ -126,7 +127,6 @@ public final class EventFileStream extends AbstractEventStream {
                 cacheSorted[index++] = event;
             }
             dispatchOrdered(c, index);
-            onFlush();
         }
     }
 


### PR DESCRIPTION
Hi,

Could I have a review of a fix that makes sure EventStream::onFlush is always called after events in a segment has been pushed.

Testing jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253505](https://bugs.openjdk.java.net/browse/JDK-8253505): JFR: onFlush invoked out of order with a sorted event stream


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/116/head:pull/116`
`$ git checkout pull/116`
