### PR TITLE
8259722: ProblemList two jdk/jfr/startupargs tests on Windows

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -850,6 +850,8 @@ jdk/jfr/event/runtime/TestNetworkUtilizationEvent.java          8228990,8229370 
 jdk/jfr/event/compiler/TestCodeSweeper.java                     8225209    generic-all
 jdk/jfr/event/os/TestThreadContextSwitches.java                 8247776 windows-all
 jdk/jfr/jmx/streaming/TestRotate.java                           8257215 generic-all
+jdk/jfr/startupargs/TestStartName.java                          8214685 windows-x64
+jdk/jfr/startupargs/TestStartDuration.java                      8214685 windows-x64
 
 ############################################################################
 


### PR DESCRIPTION
This is a trivial fix to ProblemList:

jdk/jfr/startupargs/TestStartName.java 
jdk/jfr/startupargs/TestStartDuration.java

on Windows in order to reduce the noise in the JDK16 CI.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259722](https://bugs.openjdk.java.net/browse/JDK-8259722): ProblemList two jdk/jfr/startupargs tests on Windows


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/118/head:pull/118`
`$ git checkout pull/118`
