### PR TITLE
8258643: [TESTBUG] javax/swing/JComponent/7154030/bug7154030.java failed with "Exception: Failed to hide opaque button"

### DIFF
--- a/test/jdk/javax/swing/JComponent/7154030/bug7154030.java
+++ b/test/jdk/javax/swing/JComponent/7154030/bug7154030.java
@@ -90,6 +90,7 @@ public class bug7154030 {
                 }
             });
 
+            robot.delay(1000);
             robot.waitForIdle(1000);
 
             Rectangle bounds = frame.getBounds();

--- a/test/jdk/javax/swing/JComponent/7154030/bug7154030.java
+++ b/test/jdk/javax/swing/JComponent/7154030/bug7154030.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,14 +30,9 @@ import javax.swing.JDesktopPane;
 import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
 
-import java.awt.AWTException;
-import java.awt.AlphaComposite;
 import java.awt.Color;
-import java.awt.Graphics;
-import java.awt.Graphics2D;
+import java.awt.Insets;
 import java.awt.Rectangle;
-import java.awt.Robot;
-import java.awt.Toolkit;
 import java.awt.image.BufferedImage;
 import javax.imageio.ImageIO;
 import java.io.File;
@@ -98,10 +93,11 @@ public class bug7154030 {
             robot.waitForIdle(1000);
 
             Rectangle bounds = frame.getBounds();
-            locx = bounds.x;
-            locy = bounds.y;
-            frw = bounds.width;
-            frh = bounds.height;
+            Insets insets = frame.getInsets();
+            locx = bounds.x + insets.left;
+            locy = bounds.y + insets.top;
+            frw = bounds.width - insets.left - insets.right;
+            frh = bounds.height - insets.top - insets.bottom;
 
             imageInit = robot.createScreenCapture(new Rectangle(locx, locy, frw, frh));
 


### PR DESCRIPTION
Backport from mainline.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258643](https://bugs.openjdk.java.net/browse/JDK-8258643): [TESTBUG] javax/swing/JComponent/7154030/bug7154030.java failed with "Exception: Failed to hide opaque button" ⚠️ Issue is not open.


### Reviewers
 * [Tejpal Rebari](https://openjdk.java.net/census#trebari) (@trebari - Committer) ⚠️ Review applies to c3b4e3bf7e09323b136ca8e0a1f7986c11aab01f
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**) ⚠️ Review applies to c3b4e3bf7e09323b136ca8e0a1f7986c11aab01f


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/119/head:pull/119`
`$ git checkout pull/119`
