### PR TITLE
8259641: C2: assert(early->dominates(LCA)) failed: early is high enough

### DIFF
--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -5020,7 +5020,7 @@ Node *PhaseIdealLoop::get_late_ctrl( Node *n, Node *early ) {
             for (uint j = 1; j < s->req(); j++) {
               Node* in = s->in(j);
               Node* r_in = r->in(j);
-              if (worklist.member(in) && is_dominator(early, r_in)) {
+              if ((worklist.member(in) || in == mem) && is_dominator(early, r_in)) {
                 LCA = dom_lca_for_get_late_ctrl(LCA, r_in, n);
               }
             }

--- a/test/hotspot/jtreg/compiler/loopopts/TestBrokenAntiDependenceWithPhi.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestBrokenAntiDependenceWithPhi.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8259641
+ * @summary C2: assert(early->dominates(LCA)) failed: early is high enough
+ *
+ * @run main/othervm -Xcomp -XX:CompileOnly=TestBrokenAntiDependenceWithPhi TestBrokenAntiDependenceWithPhi
+ *
+ */
+
+public class TestBrokenAntiDependenceWithPhi {
+
+    int a;
+    int b;
+    byte c;
+
+    long e(int f, int g, long h) {
+        int i[] = new int[a];
+        double j = 2.74886;
+        long k[][] = new long[a][a];
+        long l = checkSum(k);
+        return l;
+    }
+    
+    void m() {
+        int s, o, p[] = new int[a];
+        double d;
+        for (d = 5; d < 388; d++) {
+            e(b, b, 40418347472393L);
+            for (s = 3; s < 66; ++s)
+                int1array(a, 9);
+        }
+        for (o = 6; o > 2; o--)
+            p[o] = c;
+    }
+    
+    public static void main(String[] q) {
+        TestBrokenAntiDependenceWithPhi r = new TestBrokenAntiDependenceWithPhi();
+        try {
+            r.m();
+        } catch (ArrayIndexOutOfBoundsException aioobe) {
+        }
+    }
+
+    public static long checkSum(long[] a) {
+        long sum = 0;
+        for (int j = 0; j < a.length; j++) {
+            sum += (a[j] / (j + 1) + a[j] % (j + 1));
+        }
+        return sum;
+    }
+
+    public static long checkSum(long[][] a) {
+        long sum = 0;
+        for (int j = 0; j < a.length; j++) {
+            sum += checkSum(a[j]);
+        }
+        return sum;
+    }
+
+    public static int[] int1array(int sz, int seed) {
+        int[] ret = new int[sz];
+        init(ret, seed);
+        return ret;
+    }
+
+    public static void init(int[] a, int seed) {
+        for (int j = 0; j < a.length; j++) {
+            a[j] = (j % 2 == 0) ? seed + j : seed - j;
+        }
+    }
+
+}
+

--- a/test/hotspot/jtreg/compiler/loopopts/TestBrokenAntiDependenceWithPhi.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestBrokenAntiDependenceWithPhi.java
@@ -43,7 +43,7 @@ public class TestBrokenAntiDependenceWithPhi {
         long l = checkSum(k);
         return l;
     }
-    
+
     void m() {
         int s, o, p[] = new int[a];
         double d;
@@ -55,7 +55,7 @@ public class TestBrokenAntiDependenceWithPhi {
         for (o = 6; o > 2; o--)
             p[o] = c;
     }
-    
+
     public static void main(String[] q) {
         TestBrokenAntiDependenceWithPhi r = new TestBrokenAntiDependenceWithPhi();
         try {
@@ -93,4 +93,3 @@ public class TestBrokenAntiDependenceWithPhi {
     }
 
 }
-


### PR DESCRIPTION
For the fix of 8258393 that causes this regression, I wrote that the
goal was:

"I propose to be less conservative in anti-dependence analysis for
Phis. For a Phi, when computing the LCA, I think it's sufficient to
only consider region's inputs that we actually reach by following the
memory edges and that's what I propose here."

But that's not what the logic I added does. It checks whether a Phi
input should be taken into account by checking whether it's in the
worklist but the worklist doesn't include mem, the memory state from
which we started.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259641](https://bugs.openjdk.java.net/browse/JDK-8259641): C2: assert(early->dominates(LCA)) failed: early is high enough


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/121/head:pull/121`
`$ git checkout pull/121`
