### PR TITLE
8259574: SIGSEGV in BFSClosure::closure_impl

### DIFF
--- a/src/hotspot/share/jfr/leakprofiler/chains/bfsClosure.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/chains/bfsClosure.cpp
@@ -229,7 +229,7 @@ void BFSClosure::do_oop(narrowOop* ref) {
 }
 
 void BFSClosure::do_root(UnifiedOopRef ref) {
-  assert(!ref.is_null(), "invariant");
+  assert(ref.dereference() != NULL, "pointee must not be null");
   if (!_edge_queue->is_full()) {
     _edge_queue->add(NULL, ref);
   }

--- a/src/hotspot/share/jfr/leakprofiler/chains/rootSetClosure.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/chains/rootSetClosure.cpp
@@ -57,7 +57,7 @@ template <typename Delegate>
 void RootSetClosure<Delegate>::do_oop(narrowOop* ref) {
   assert(ref != NULL, "invariant");
   assert(is_aligned(ref, sizeof(narrowOop)), "invariant");
-  if (CompressedOops::is_null(*ref)) {
+  if (!CompressedOops::is_null(*ref)) {
     _delegate->do_root(UnifiedOopRef::encode_in_native(ref));
   }
 }

--- a/src/hotspot/share/jfr/recorder/repository/jfrEmergencyDump.cpp
+++ b/src/hotspot/share/jfr/recorder/repository/jfrEmergencyDump.cpp
@@ -524,7 +524,6 @@ class JavaThreadInVMAndNative : public StackObj {
 };
 
 static void post_events(bool exception_handler, Thread* thread) {
-  DEBUG_ONLY(JfrJavaSupport::check_java_thread_in_vm(thread));
   if (exception_handler) {
     EventShutdown e;
     e.set_reason("VM Error");


### PR DESCRIPTION
Greetings,

please help review this small adjustment to get the JFR Memory Leak Profiler working again.

Testing: jdk_jfr

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259574](https://bugs.openjdk.java.net/browse/JDK-8259574): SIGSEGV in BFSClosure::closure_impl


### Reviewers
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**)
 * [Erik Gahlin](https://openjdk.java.net/census#egahlin) (@egahlin - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/125/head:pull/125`
`$ git checkout pull/125`
