### PR TITLE
8257215: JFR: Events dropped when streaming over a chunk rotation

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecording.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecording.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecording.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecording.java
@@ -41,6 +41,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -850,5 +851,19 @@ public final class PlatformRecording implements AutoCloseable {
             }
         }
 
+    }
+
+    public void removePath(SafePath path) {
+        synchronized (recorder) {
+            Iterator<RepositoryChunk> it = chunks.iterator();
+            while (it.hasNext()) {
+                RepositoryChunk c = it.next();
+                if (c.getFile().equals(path)) {
+                    it.remove();
+                    removed(c);
+                    return;
+                }
+            }
+        }
     }
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/Repository.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/Repository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/Repository.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/Repository.java
@@ -33,6 +33,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import jdk.jfr.internal.SecuritySupport.SafePath;
+import jdk.jfr.internal.management.ChunkFilename;
 
 public final class Repository {
 
@@ -45,6 +46,7 @@ public final class Repository {
     private final Set<SafePath> cleanupDirectories = new HashSet<>();
     private SafePath baseLocation;
     private SafePath repository;
+    private ChunkFilename chunkFilename;
 
     private Repository() {
     }
@@ -61,6 +63,7 @@ public final class Repository {
         // Probe to see if repository can be created, needed for fail fast
         // during JVM startup or JFR.configure
         this.repository = createRepository(baseLocation);
+        this.chunkFilename = null;
         try {
             // Remove so we don't "leak" repositories, if JFR is never started
             // and shutdown hook not added.
@@ -84,8 +87,13 @@ public final class Repository {
                 jvm.setRepositoryLocation(repository.toString());
                 SecuritySupport.setProperty(JFR_REPOSITORY_LOCATION_PROPERTY, repository.toString());
                 cleanupDirectories.add(repository);
+                chunkFilename = null;
             }
-            return new RepositoryChunk(repository, timestamp);
+            if (chunkFilename == null) {
+                chunkFilename = ChunkFilename.newPriviliged(repository.toPath());
+            }
+            String filename = chunkFilename.next(timestamp.toLocalDateTime());
+            return new RepositoryChunk(new SafePath(filename), timestamp.toInstant());
         } catch (Exception e) {
             String errorMsg = String.format("Could not create chunk in repository %s, %s: %s", repository, e.getClass(), e.getMessage());
             Logger.log(LogTag.JFR, LogLevel.ERROR, errorMsg);

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/RepositoryChunk.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/RepositoryChunk.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/RepositoryChunk.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/RepositoryChunk.java
@@ -35,7 +35,6 @@ import java.time.ZonedDateTime;
 import java.util.Comparator;
 
 import jdk.jfr.internal.SecuritySupport.SafePath;
-import jdk.jfr.internal.management.ChunkFilename;
 
 final class RepositoryChunk {
     private static final int MAX_CHUNK_NAMES = 100;

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/RepositoryChunk.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/RepositoryChunk.java
@@ -74,7 +74,7 @@ final class RepositoryChunk {
             String extendedName = String.format("%s_%02d%s", filename, i, FILE_EXTENSION);
             p = directory.toPath().resolve(extendedName);
         }
-        p = directory.toPath().resolve(filename + "_" + System.currentTimeMillis() + FILE_EXTENSION);
+        p = directory.toPath().resolve(filename + "_UTC_" + System.currentTimeMillis() + FILE_EXTENSION);
         return new SafePath(p);
     }
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/RepositoryChunk.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/RepositoryChunk.java
@@ -35,6 +35,7 @@ import java.time.ZonedDateTime;
 import java.util.Comparator;
 
 import jdk.jfr.internal.SecuritySupport.SafePath;
+import jdk.jfr.internal.management.ChunkFilename;
 
 final class RepositoryChunk {
     private static final int MAX_CHUNK_NAMES = 100;
@@ -47,7 +48,6 @@ final class RepositoryChunk {
         }
     };
 
-    private final SafePath repositoryPath;
     private final SafePath chunkFile;
     private final Instant startTime;
     private final RandomAccessFile unFinishedRAF;
@@ -56,26 +56,10 @@ final class RepositoryChunk {
     private int refCount = 0;
     private long size;
 
-    RepositoryChunk(SafePath path, ZonedDateTime timestamp) throws Exception {
-        this.startTime = timestamp.toInstant();
-        this.repositoryPath = path;
-        this.chunkFile = findFileName(repositoryPath, timestamp.toLocalDateTime());
+    RepositoryChunk(SafePath path, Instant startTime) throws Exception {
+        this.startTime = startTime;
+        this.chunkFile = path;
         this.unFinishedRAF = SecuritySupport.createRandomAccessFile(chunkFile);
-    }
-
-    private static SafePath findFileName(SafePath directory, LocalDateTime time) throws Exception {
-        String filename = Utils.formatDateTime(time);
-        Path p = directory.toPath().resolve(filename + FILE_EXTENSION);
-        for (int i = 1; i < MAX_CHUNK_NAMES; i++) {
-            SafePath s = new SafePath(p);
-            if (!SecuritySupport.exists(s)) {
-                return s;
-            }
-            String extendedName = String.format("%s_%02d%s", filename, i, FILE_EXTENSION);
-            p = directory.toPath().resolve(extendedName);
-        }
-        p = directory.toPath().resolve(filename + "_UTC_" + System.currentTimeMillis() + FILE_EXTENSION);
-        return new SafePath(p);
     }
 
     void finish(Instant endTime) {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/SecuritySupport.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/SecuritySupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/SecuritySupport.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/SecuritySupport.java
@@ -500,6 +500,11 @@ public final class SecuritySupport {
         public  long fileSize(Path p) throws IOException {
             return doPrivilegedIOWithReturn( () -> Files.size(p));
         }
+
+        @Override
+        public boolean exists(Path p) throws IOException {
+            return doPrivilegedIOWithReturn( () -> Files.exists(p));
+        }
     }
 
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/Utils.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/Utils.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/Utils.java
@@ -184,7 +184,7 @@ public final class Utils {
 
     // This method reduces the number of loaded classes
     // compared to DateTimeFormatter
-    static String formatDateTime(LocalDateTime time) {
+    public static String formatDateTime(LocalDateTime time) {
         StringBuilder sb = new StringBuilder(19);
         sb.append(time.getYear() / 100);
         appendPadded(sb, time.getYear() % 100, true);

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/FileAccess.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/FileAccess.java
@@ -46,6 +46,8 @@ public abstract class FileAccess {
 
     public abstract long fileSize(Path p) throws IOException;
 
+    public abstract boolean exists(Path s) throws IOException;
+
     private static class UnPrivileged extends FileAccess {
         @Override
         public RandomAccessFile openRAF(File f, String mode) throws IOException {
@@ -71,5 +73,11 @@ public abstract class FileAccess {
         public long fileSize(Path p) throws IOException {
             return Files.size(p);
         }
+
+        @Override
+        public boolean exists(Path p) {
+            return Files.exists(p);
+        }
     }
+
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/FileAccess.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/FileAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -79,5 +79,4 @@ public abstract class FileAccess {
             return Files.exists(p);
         }
     }
-
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/OngoingStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/OngoingStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/OngoingStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/OngoingStream.java
@@ -119,8 +119,7 @@ public final class OngoingStream extends EventByteStream {
                     throw new IOException("No progress");
                 }
                 startTimeNanos += header.getDurationNanos();
-                Instant timestamp = Utils.epochNanosToInstant(startTimeNanos);
-                ManagementSupport.removeBefore(recording, timestamp);
+                ManagementSupport.removePath(recording, path);
                 closeInput();
             } else {
                 header.refresh();

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/management/ChunkFilename.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/management/ChunkFilename.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.jfr.internal.management;
+
+import java.nio.file.Paths;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+import jdk.jfr.internal.SecuritySupport;
+import jdk.jfr.internal.SecuritySupport.SafePath;
+import jdk.jfr.internal.Utils;
+import jdk.jfr.internal.consumer.FileAccess;
+
+// Allows a remote streaming client to create chunk files
+// with same naming scheme as the JVM.
+public final class ChunkFilename {
+   private static final int MAX_CHUNK_NAMES = 100_000;
+   private static final String FILE_EXTENSION = ".jfr";
+
+   private final Path directory;
+   private final FileAccess fileAcess;
+
+   private Path lastPath;
+   private int counter;
+
+   public static ChunkFilename newUnpriviliged(Path directory) {
+       return new ChunkFilename(directory, FileAccess.UNPRIVILEGED);
+   }
+
+   public static ChunkFilename newPriviliged(Path directory) {
+       return new ChunkFilename(directory, SecuritySupport.PRIVILEGED);
+   }
+
+   private ChunkFilename(Path directory, FileAccess fileAccess) {
+       // Avoid malicious implementations of Path interface
+       this.directory = Paths.get(directory.toString());
+       this.fileAcess = fileAccess;
+   }
+
+   public String next(LocalDateTime time) throws IOException {
+       String filename = Utils.formatDateTime(time);
+       Path p = directory.resolve(filename + FILE_EXTENSION);
+
+       // If less than one file per second (typically case)
+       if (lastPath == null || !p.equals(lastPath)) {
+           if (!fileAcess.exists(p)) {
+               counter = 1; // reset counter
+               lastPath = p;
+               return p.toString();
+           }
+       }
+
+       // If more than one file per second
+       while (counter < MAX_CHUNK_NAMES) {
+           String extendedName = String.format("%s_%02d%s", filename, counter, FILE_EXTENSION);
+           p = directory.resolve(extendedName);
+           counter++;
+           if (!fileAcess.exists(p)) {
+               return p.toString();
+           }
+       }
+       throw new IOException("Unable to find unused filename after " + counter + " attempts");
+   }
+}

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/management/ManagementSupport.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/management/ManagementSupport.java
@@ -49,6 +49,7 @@ import jdk.jfr.internal.Logger;
 import jdk.jfr.internal.MetadataRepository;
 import jdk.jfr.internal.PlatformRecording;
 import jdk.jfr.internal.PrivateAccess;
+import jdk.jfr.internal.SecuritySupport.SafePath;
 import jdk.jfr.internal.Utils;
 import jdk.jfr.internal.WriteableUserPath;
 import jdk.jfr.internal.consumer.EventDirectoryStream;
@@ -141,7 +142,12 @@ public final class ManagementSupport {
     public static void removeBefore(Recording recording, Instant timestamp) {
         PlatformRecording pr = PrivateAccess.getInstance().getPlatformRecording(recording);
         pr.removeBefore(timestamp);
+    }
 
+    // Needed callback to detect when a chunk has been parsed.
+    public static void removePath(Recording recording, Path path) {
+        PlatformRecording pr = PrivateAccess.getInstance().getPlatformRecording(recording);
+        pr.removePath(new SafePath(path));
     }
 
     // Needed callback to detect when a chunk has been parsed.
@@ -172,4 +178,6 @@ public final class ManagementSupport {
             List<Configuration> confs) throws IOException {
         return new EventDirectoryStream(acc, directory, FileAccess.UNPRIVILEGED, null, confs);
     }
+
+
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/management/ManagementSupport.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/management/ManagementSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -178,6 +178,4 @@ public final class ManagementSupport {
             List<Configuration> confs) throws IOException {
         return new EventDirectoryStream(acc, directory, FileAccess.UNPRIVILEGED, null, confs);
     }
-
-
 }

--- a/src/jdk.management.jfr/share/classes/jdk/management/jfr/DiskRepository.java
+++ b/src/jdk.management.jfr/share/classes/jdk/management/jfr/DiskRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.management.jfr/share/classes/jdk/management/jfr/DiskRepository.java
+++ b/src/jdk.management.jfr/share/classes/jdk/management/jfr/DiskRepository.java
@@ -74,6 +74,7 @@ final class DiskRepository implements Closeable {
     static final int HEADER_START_NANOS_POSITION = 32;
     static final int HEADER_SIZE = 68;
     static final int HEADER_FILE_DURATION = 40;
+    static final String FILE_EXTENSION = ".jfr";
 
     private final Deque<DiskChunk> activeChunks = new ArrayDeque<>();
     private final Deque<DiskChunk> deadChunks = new ArrayDeque<>();
@@ -326,7 +327,7 @@ final class DiskRepository implements Closeable {
         ZoneOffset z = OffsetDateTime.now().getOffset();
         LocalDateTime d = LocalDateTime.ofEpochSecond(epochSecond, nanoOfSecond, z);
         String filename = formatDateTime(d);
-        Path p1 = directory.resolve(filename + ".jfr");
+        Path p1 = directory.resolve(filename + FILE_EXTENSION);
         if (!Files.exists(p1)) {
             return new DiskChunk(p1, nanos);
         }
@@ -335,12 +336,13 @@ final class DiskRepository implements Closeable {
             if (i < 10) {
                 s = "0" + s;
             }
-            Path p2 = directory.resolve(filename + "_" + s + ".jfr");
+            Path p2 = directory.resolve(filename + "_" + s + FILE_EXTENSION);
             if (!Files.exists(p2)) {
                 return new DiskChunk(p2, nanos);
             }
         }
-        throw new IOException("Could not create chunk for path " + p1);
+        Path p = directory.resolve(filename + "_UTC_" + System.currentTimeMillis() + FILE_EXTENSION);
+        return new DiskChunk(p, nanos);
     }
 
     static String formatDateTime(LocalDateTime time) {

--- a/src/jdk.management.jfr/share/classes/jdk/management/jfr/DiskRepository.java
+++ b/src/jdk.management.jfr/share/classes/jdk/management/jfr/DiskRepository.java
@@ -49,7 +49,6 @@ final class DiskRepository implements Closeable {
     final static class DiskChunk {
         final Path path;
         final long startTimeNanos;
-        long endTimeNanos;
         Instant endTime;
         long size;
 
@@ -77,7 +76,6 @@ final class DiskRepository implements Closeable {
     static final int HEADER_START_NANOS_POSITION = 32;
     static final int HEADER_SIZE = 68;
     static final int HEADER_FILE_DURATION = 40;
-    static final String FILE_EXTENSION = ".jfr";
 
     private final Deque<DiskChunk> activeChunks = new ArrayDeque<>();
     private final Deque<DiskChunk> deadChunks = new ArrayDeque<>();
@@ -301,8 +299,8 @@ final class DiskRepository implements Closeable {
             previousRAFstate = state;
             currentChunk.size = Files.size(currentChunk.path);
             long durationNanos = buffer.getLong(HEADER_FILE_DURATION);
-            currentChunk.endTimeNanos = currentChunk.startTimeNanos + durationNanos;
-            currentChunk.endTime = ManagementSupport.epochNanosToInstant(currentChunk.endTimeNanos);
+            long endTimeNanos = currentChunk.startTimeNanos + durationNanos;
+            currentChunk.endTime = ManagementSupport.epochNanosToInstant(endTimeNanos);
         }
         raf.seek(position);
     }

--- a/src/jdk.management.jfr/share/classes/jdk/management/jfr/DownLoadThread.java
+++ b/src/jdk.management.jfr/share/classes/jdk/management/jfr/DownLoadThread.java
@@ -38,6 +38,7 @@ final class DownLoadThread extends Thread {
     private final DiskRepository diskRepository;
 
     DownLoadThread(RemoteRecordingStream stream) {
+        this.setName("JFR: Download Recording Stream " + stream.recordingId);
         this.stream = stream;
         this.startTime = stream.startTime;
         this.endTime = stream.endTime;

--- a/src/jdk.management.jfr/share/classes/jdk/management/jfr/DownLoadThread.java
+++ b/src/jdk.management.jfr/share/classes/jdk/management/jfr/DownLoadThread.java
@@ -29,6 +29,8 @@ import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 
+import jdk.jfr.internal.management.ManagementSupport;
+
 final class DownLoadThread extends Thread {
     private final RemoteRecordingStream stream;
     private final Instant startTime;
@@ -65,7 +67,7 @@ final class DownLoadThread extends Thread {
                 }
             }
         } catch (IOException ioe) {
-           // ignore
+            ManagementSupport.logDebug(ioe.getMessage());
         } finally {
            diskRepository.complete();
         }

--- a/src/jdk.management.jfr/share/classes/jdk/management/jfr/DownLoadThread.java
+++ b/src/jdk.management.jfr/share/classes/jdk/management/jfr/DownLoadThread.java
@@ -37,8 +37,8 @@ final class DownLoadThread extends Thread {
     private final Instant endTime;
     private final DiskRepository diskRepository;
 
-    DownLoadThread(RemoteRecordingStream stream) {
-        this.setName("JFR: Download Recording Stream " + stream.recordingId);
+    DownLoadThread(RemoteRecordingStream stream, String name) {
+        super(name);
         this.stream = stream;
         this.startTime = stream.startTime;
         this.endTime = stream.endTime;

--- a/src/jdk.management.jfr/share/classes/jdk/management/jfr/RemoteRecordingStream.java
+++ b/src/jdk.management.jfr/share/classes/jdk/management/jfr/RemoteRecordingStream.java
@@ -551,8 +551,8 @@ public final class RemoteRecordingStream implements EventStream {
     }
 
     private void startDownload() {
-        Thread downLoadThread = new DownLoadThread(this);
-        downLoadThread.setName("JFR: Download Thread " + creationTime);
+        String name = "JFR: Download Thread " + creationTime;
+        Thread downLoadThread = new DownLoadThread(this, name);
         downLoadThread.start();
     }
 

--- a/src/jdk.management.jfr/share/classes/jdk/management/jfr/RemoteRecordingStream.java
+++ b/src/jdk.management.jfr/share/classes/jdk/management/jfr/RemoteRecordingStream.java
@@ -133,8 +133,7 @@ public final class RemoteRecordingStream implements EventStream {
 
         @Override
         public void accept(Long endNanos) {
-            Instant t = ManagementSupport.epochNanosToInstant(endNanos);
-            repository.onChunkComplete(t);
+            repository.onChunkComplete(endNanos);
         }
     }
 

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -849,7 +849,6 @@ javax/script/Test7.java                                         8239361 generic-
 jdk/jfr/event/runtime/TestNetworkUtilizationEvent.java          8228990,8229370    generic-all
 jdk/jfr/event/compiler/TestCodeSweeper.java                     8225209    generic-all
 jdk/jfr/event/os/TestThreadContextSwitches.java                 8247776 windows-all
-jdk/jfr/jmx/streaming/TestRotate.java                           8257215 generic-all
 jdk/jfr/startupargs/TestStartName.java                          8214685 windows-x64
 jdk/jfr/startupargs/TestStartDuration.java                      8214685 windows-x64
 

--- a/test/jdk/jdk/jfr/jmx/streaming/TestRotate.java
+++ b/test/jdk/jdk/jfr/jmx/streaming/TestRotate.java
@@ -44,7 +44,7 @@ import jdk.management.jfr.RemoteRecordingStream;
  * @summary Tests that streaming can work over chunk rotations
  * @requires vm.hasJFR
  * @library /test/lib /test/jdk
- * @run main/othervm jdk.jfr.jmx.streaming.TestRotate
+ * @run main/othervm -Xlog:jfr=debug jdk.jfr.jmx.streaming.TestRotate
  */
 public class TestRotate {
 


### PR DESCRIPTION
Hi, 

Could I have review of an intermittent product issue. It happens about 1 out of 300 the test is run.

By design, chunk files that have been parsed are deleted. Problem is that the filename could be reused, which causes issues. This happens on the server, where the files are read before they are transfered over the network, and on the client when chunks are read from the local repository. 

The logic for creating the chunk file names is now in a separate class (ChunkFilename) so it can be shared by server and client. Another problem was the clock source being used when purging files. It was not always the same as when timestamp was taken from the chunk.

Testing: Ran TestRotate.java 2100 times without failure

Testing: jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257215](https://bugs.openjdk.java.net/browse/JDK-8257215): JFR: Events dropped when streaming over a chunk rotation


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/131/head:pull/131`
`$ git checkout pull/131`
