### PR TITLE
8260370: C2: LoopLimit node is not eliminated

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -1840,6 +1840,8 @@ void Compile::process_for_post_loop_opts_igvn(PhaseIterGVN& igvn) {
 
   C->set_post_loop_opts_phase(); // no more loop opts allowed
 
+  assert(!C->major_progress(), "not cleared");
+
   if (_for_post_loop_igvn.length() > 0) {
     while (_for_post_loop_igvn.length() > 0) {
       Node* n = _for_post_loop_igvn.pop();
@@ -1848,6 +1850,11 @@ void Compile::process_for_post_loop_opts_igvn(PhaseIterGVN& igvn) {
     }
     igvn.optimize();
     assert(_for_post_loop_igvn.length() == 0, "no more delayed nodes allowed");
+
+    // Sometimes IGVN sets major progress (e.g., when processing loop nodes).
+    if (C->major_progress()) {
+      C->clear_major_progress(); // ensure that major progress is now clear
+    }
   }
 }
 

--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -1921,8 +1921,9 @@ Node *LoopLimitNode::Ideal(PhaseGVN *phase, bool can_reshape) {
 
   // Delay following optimizations until all loop optimizations
   // done to keep Ideal graph simple.
-  if (!can_reshape || phase->C->major_progress())
+  if (!can_reshape || !phase->C->post_loop_opts_phase()) {
     return NULL;
+  }
 
   const TypeInt* init_t  = phase->type(in(Init) )->is_int();
   const TypeInt* limit_t = phase->type(in(Limit))->is_int();


### PR DESCRIPTION
As part of JDK-8255000 `C->major_progress` check was replaced with an explicit phase check (`post_loop_opts_phase()`).
But `LoopLimit` was not covered and still relied on `C->major_progress()`. It exposed a problem: sometimes IGVN sets `major_progress` (e.g., see `LoopNode::Ideal()`) and it blocks `LoopLimit` node elimination if the node is processed later (`LoopLimitNode::Ideal()` is misled that loop opts phase is not over).         

The fix migrates `LoopLimitNode::Ideal()` to  `post_loop_opts_phase()`. 

Also, post-loop opts IGVN pass conservatively clears `major_progress()` just in case.  
   
Testing:
- [x] failing test
- [x] hs-tier1 - hs-tier4

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260370](https://bugs.openjdk.java.net/browse/JDK-8260370): C2: LoopLimit node is not eliminated


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/134/head:pull/134`
`$ git checkout pull/134`
