### PR TITLE
8260632: Build failures after JDK-8253353

### DIFF
--- a/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.cpp
+++ b/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.cpp
@@ -2285,7 +2285,7 @@ void MemoryGraphFixer::collect_memory_nodes() {
   uint last = _phase->C->unique();
 
 #ifdef ASSERT
-  uint8_t max_depth = 0;
+  uint16_t max_depth = 0;
   for (LoopTreeIterator iter(_phase->ltree_root()); !iter.done(); iter.next()) {
     IdealLoopTree* lpt = iter.current();
     max_depth = MAX2(max_depth, lpt->_nest);


### PR DESCRIPTION
[JDK-8253353](https://bugs.openjdk.java.net/browse/JDK-8253353) changed the field to `uint16_t`, and now `shenadoahSupport.cpp` code runs into ambiguity choosing between `uint8_t` and `uint16_t` when instantiating `MAX2` macro:

```
/home/buildbot/worker/build-jdk16u-linux/build/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.cpp:2291:43: error: no matching function for call to 'MAX2(uint8_t&, uint16_t&)'
     max_depth = MAX2(max_depth, lpt->_nest);
                                           ^
In file included from /home/buildbot/worker/build-jdk16u-linux/build/src/hotspot/share/metaprogramming/primitiveConversions.hpp:30:0,
                 from /home/buildbot/worker/build-jdk16u-linux/build/src/hotspot/share/oops/oopHandle.hpp:28,
                 from /home/buildbot/worker/build-jdk16u-linux/build/src/hotspot/share/classfile/systemDictionary.hpp:28,
                 from /home/buildbot/worker/build-jdk16u-linux/build/src/hotspot/share/classfile/javaClasses.hpp:28,
                 from /home/buildbot/worker/build-jdk16u-linux/build/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.cpp:27:
```

Additional testing:
 - [x] Linux x86_64 `hotspot_gc_shenandoah`
 - [x] Linux x86_64 `tier1` with Shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260632](https://bugs.openjdk.java.net/browse/JDK-8260632): Build failures after JDK-8253353


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/138/head:pull/138`
`$ git checkout pull/138`
