### PR TITLE
8260927: StringBuilder::insert is incorrect without Compact Strings

### DIFF
--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -3621,7 +3621,7 @@ public final class String
      */
     void getBytes(byte[] dst, int srcPos, int dstBegin, byte coder, int length) {
         if (coder() == coder) {
-            System.arraycopy(value, srcPos, dst, dstBegin << coder, length << coder());
+            System.arraycopy(value, srcPos << coder, dst, dstBegin << coder, length << coder);
         } else {    // this.coder == LATIN && coder == UTF16
             StringLatin1.inflate(value, srcPos, dst, dstBegin, length);
         }

--- a/test/jdk/java/lang/StringBuilder/Insert.java
+++ b/test/jdk/java/lang/StringBuilder/Insert.java
@@ -27,9 +27,10 @@ import static org.testng.Assert.assertEquals;
 
 /**
  * @test
- * @run testng Insert
  * @bug 4914802 8257511
  * @summary Test StringBuilder.insert sanity tests
+ * @run testng/othervm -XX:-CompactStrings Insert
+ * @run testng/othervm -XX:+CompactStrings Insert
  */
 @Test
 public class Insert {


### PR DESCRIPTION
Discovered it with ARM32 tier1 tests, which runs with -CompactStrings by default. But the bug is actually generic:

```
$ CONF=linux-x86_64-server-fastdebug make run-test TEST=java/lang/StringBuilder/Insert.java TEST_VM_OPTS="-XX:-CompactStrings"

test Insert.insertOffset(): failure
java.lang.AssertionError: expected [??abc] but found [efabc]
	at org.testng.Assert.fail(Assert.java:94)
	at org.testng.Assert.failNotEquals(Assert.java:496)
	at org.testng.Assert.assertEquals(Assert.java:125)
	at org.testng.Assert.assertEquals(Assert.java:178)
	at org.testng.Assert.assertEquals(Assert.java:188)
	at Insert.insertOffset(Insert.java:45)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
```

I believe this is a regression from [JDK-8254082](https://bugs.openjdk.java.net/browse/JDK-8254082). 

```
    void getBytes(byte[] dst, int srcPos, int dstBegin, byte coder, int length) {
        if (coder() == coder) {
            System.arraycopy(value, srcPos, dst, dstBegin << coder, length << coder());
        } else {    // this.coder == LATIN && coder == UTF16
            StringLatin1.inflate(value, srcPos, dst, dstBegin, length);
        }
    }
```

When coder is `UTF16` (which it guaranteed to be without `CompactStrings`), then `srcPos` in `byte[]` array has to be adjusted by `coder` as well.

Additional testing:
 - [x] Linux ARM32, affected test now passes
 - [x] Linux x86_64, affected test now passes
 - [x] Linux x86_64 `tier1` default, passes
 - [x] Linux x86_64 `tier1`, `-XX:-CompactStrings`, passes modulo two testbugs ([JDK-8260933](https://bugs.openjdk.java.net/browse/JDK-8260933), [JDK-8260934](https://bugs.openjdk.java.net/browse/JDK-8260934))
 - [x] Linux x86_64 `tier2` default, passes
 - [x] Linux x86_64 `tier2`, `-XX:-CompactStrings`, passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260927](https://bugs.openjdk.java.net/browse/JDK-8260927): StringBuilder::insert is incorrect without Compact Strings


### Reviewers
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Jim Laskey](https://openjdk.java.net/census#jlaskey) (@JimLaskey - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/143/head:pull/143`
`$ git checkout pull/143`
