### PR TITLE
8260709: C2: assert(false) failed: unscheduable graph

### DIFF
--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -1607,6 +1607,8 @@ public:
   void check_long_counted_loop(IdealLoopTree* loop, Node* x) NOT_DEBUG_RETURN;
 
   LoopNode* create_inner_head(IdealLoopTree* loop, LongCountedLoopNode* head, LongCountedLoopEndNode* exit_test);
+
+  bool is_safe_load_ctrl(Node* ctrl);
 };
 
 

--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1429,7 +1429,7 @@ void PhaseIdealLoop::split_if_with_blocks_post(Node *n) {
         // If n is a load, and the late control is the same as the current
         // control, then the cloning of n is a pointless exercise, because
         // GVN will ensure that we end up where we started.
-        if (!n->is_Load() || late_load_ctrl != n_ctrl) {
+        if (!n->is_Load() || (late_load_ctrl != n_ctrl && is_safe_load_ctrl(late_load_ctrl))) {
           for (DUIterator_Last jmin, j = n->last_outs(jmin); j >= jmin; ) {
             Node *u = n->last_out(j); // Clone private computation per use
             _igvn.rehash_node_delayed(u);
@@ -1523,6 +1523,13 @@ void PhaseIdealLoop::split_if_with_blocks_post(Node *n) {
       get_loop(get_ctrl(n)) == get_loop(get_ctrl(n->in(1))) ) {
     _igvn.replace_node( n, n->in(1) );
   }
+}
+
+bool PhaseIdealLoop::is_safe_load_ctrl(Node* ctrl) {
+  if (ctrl->is_Proj() && ctrl->in(0)->is_Call() && ctrl->has_out_with(Op_Catch)) {
+    return false;
+  }
+  return true;
 }
 
 //------------------------------split_if_with_blocks---------------------------

--- a/test/hotspot/jtreg/compiler/loopopts/TestLoadPinnedAfterAllocate.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestLoadPinnedAfterAllocate.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8260709
+ * @summary C2: assert(false) failed: unscheduable graph
+ *
+ * @run main/othervm -XX:-BackgroundCompilation TestLoadPinnedAfterAllocate
+ *
+ */
+
+public class TestLoadPinnedAfterAllocate {
+    private int field;
+    private static volatile int barrier;
+    private static Object field2;
+
+    public static void main(String[] args) {
+        final TestLoadPinnedAfterAllocate test = new TestLoadPinnedAfterAllocate();
+        for (int i = 0; i < 20_000; i++) {
+            test.test(1, 10);
+        }
+    }
+
+    private int test(int start, int stop) {
+        int[] array = new int[10];
+        for (int j = 0; j < 10; j++) {
+            barrier = 1;
+            // early control for field load below
+            for (int i = 1; i < 10; i *= 2) {
+                field2 = array;
+                array = new int[10];
+                // late control for field load below
+            }
+        }
+        int v = field;
+        array[0] = v;
+        return v+v;
+    }
+}


### PR DESCRIPTION
The v = field load in the test case is found anti-dependent with the
memory phi that merges the exception state of the 2 array
allocation. Since JDK-8258393, anti-dependence computation only
considers the Phi inputs that are reachable from the memory input of a
load. As a consequence, the late control for the load is the control
projection of the array allocation in the loop. When loop opts run,
PhaseIdealLoop::split_if_with_blocks_post() finds that the load's late
control is different from its current control (which is inside the
outer loop). It tries to sink the load out of loop but ends up pinning
it at its late control, the projection of the second AllocateNode.

The logic that expands the AllocateNode doesn't expect a pinned node
on the control projection and the result is a broken graph. I think
the fix for this would be to clone the load along both the exception
and the fallthrough paths. But as noted in JDK-8252372, the whole
process of sinking loads out of loops doesn't seem to work as expected
(for instance in this case it sinks the load from the outer loop into
the inner loop). So instead of going with a complicated fix, I propose
simply to detect this corner and that no attempt be made to sink the
load. Note that the current logic computes the late control for the
load (which should be in the loop), will create a clone for each use
and assign the dom_lca of the use's control and the load late control
to that use, that is the load late control. So all uses end up at the
same location, the load late control. So to detect that case, it's
sufficient to test the load late control.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260709](https://bugs.openjdk.java.net/browse/JDK-8260709): C2: assert(false) failed: unscheduable graph


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16 pull/144/head:pull/144`
`$ git checkout pull/144`
